### PR TITLE
Working helm chart and some refactoring

### DIFF
--- a/helm/vmss-prototype/.helmignore
+++ b/helm/vmss-prototype/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+test/

--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+description: A Helm chart for the Kamino vmss-prototype pattern image generator
+name: vmss-prototype
+version: 0.0.1
+maintainers:
+  - name: Michael Sinz
+    email: msinz@microsoft.com
+home: https://speechwiki.azurewebsites.net/architecture/skyman-vmss-prototype-pattern.html
+sources:
+  - https://github.com/Michael-Sinz/kamino
+keywords:
+  - vmss
+  - azure
+  - kubernetes
+  - kamino

--- a/helm/vmss-prototype/templates/_image.tpl
+++ b/helm/vmss-prototype/templates/_image.tpl
@@ -1,0 +1,17 @@
+{{/*
+Create full container image name by either hash or tag. It requires specific layout within the container scope
+*/}}
+{{- define "image.full" -}}
+{{- if .pullByHash }}
+{{- printf "%s/%s@sha256:%s" .imageRegistry .imageRepository .imageHash -}}
+{{- else }}
+{{- printf "%s/%s:%s" .imageRegistry .imageRepository .imageTag -}}
+{{- end }}
+{{- end -}}
+
+{{/*
+Create a pull policy based on whether we pull by hash or tag
+*/}}
+{{- define "image.pull" -}}
+{{- if .pullByHash -}}IfNotPresent{{- else -}}Always{{- end -}}
+{{- end -}}

--- a/helm/vmss-prototype/templates/vmss-prototype.yaml
+++ b/helm/vmss-prototype/templates/vmss-prototype.yaml
@@ -1,0 +1,132 @@
+{{- if hasKey .Values "kamino" -}}
+{{- $jobName := printf "%s-%s" .Values.kamino.name "status" -}}
+{{- if hasKey .Values.kamino "targetNode" -}}
+{{- $jobName = printf "%s-%s" .Values.kamino.name (substr 0 (int (sub (len .Values.kamino.targetNode) 6)) .Values.kamino.targetNode) -}}
+{{- end -}}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $jobName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.kamino.labels.app }}
+    kamino: {{ $jobName }}
+    helm/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    {{- if hasKey .Values.kamino "targetNode" }}
+    targetNode: {{ .Values.kamino.targetNode }}
+    {{- end }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.kamino.labels.app }}
+        kamino: {{ $jobName }}
+        helm/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        {{- if hasKey .Values.kamino "targetNode" }}
+        targetNode: {{ .Values.kamino.targetNode }}
+        {{- end }}
+    spec:
+      restartPolicy: Never
+
+      {{- if hasKey .Values.kamino.container "pullSecret" }}
+      imagePullSecrets:
+        - name: {{ .Values.kamino.container.pullSecret }}
+      {{- end}}
+
+      # We set up a required affinity run on a node that is
+      # note the target node we are about to shut down.
+      # (Only if we have a targetNode)
+      {{- if hasKey .Values.kamino "targetNode" }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchFields:
+              - key: metadata.name
+                operator: NotIn
+                values:
+                - {{ .Values.kamino.targetNode }}
+      {{- end }}
+
+      containers:
+        - name: {{ .Values.kamino.name }}
+          image: {{ template "image.full" .Values.kamino.container }}
+          imagePullPolicy: {{ template "image.pull" .Values.kamino.container }}
+
+          command:
+            - vmss-prototype
+          args:
+            - --in-cluster
+            - --log-level
+            - {{ required "missing required kamino.logLevel" .Values.kamino.logLevel }}
+            {{- if hasKey .Values.kamino "targetNode" }}
+            # Use the target node as our source for the new prototype image
+            - update
+            - --target-node
+            - {{ .Values.kamino.targetNode | quote }}
+            - --grace-period
+            - {{ required "missing required kamino.drain.gracePeriod" .Values.kamino.drain.gracePeriod | quote }}
+            - --max-history
+            - {{ required "missing required kamino.imageHistory" .Values.kamino.imageHistory | quote }}
+            {{- else }}
+            # Just a status run
+            - status
+            {{- end }}
+
+          env:
+            # We use the in-cluster kubeconfig
+            - name: KUBECONFIG
+              value: /.kubeconfig
+
+            # This gets mapped here since the node has cloud local CA bundles we need
+            - name: REQUESTS_CA_BUNDLE
+              value: /etc/ssl/certs/ca-certificates.crt
+
+            # Pass in the name of the node on which this pod is scheduled
+            # This is not actually used right now... will be in the future
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+
+          volumeMounts:
+            - name: host-sp
+              mountPath: /etc/kubernetes
+              readOnly: true
+            - name: kubectl
+              mountPath: /usr/bin/kubectl
+              readOnly: true
+            - name: kubeconfig
+              mountPath: /.kubeconfig
+              readOnly: true
+            - name: host-crt
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              readOnly: true
+
+      volumes:
+        - name: host-sp
+          hostPath:
+            # this file contains the cluster specific details, including azure info
+            path: /etc/kubernetes
+            type: Directory
+
+        - name: kubectl
+          hostPath:
+            path: /usr/local/bin/kubectl
+            type: File
+
+        - name: kubeconfig
+          hostPath:
+            path: /var/lib/kubelet/kubeconfig
+            type: File
+
+        - name: host-crt
+          hostPath:
+            path: /etc/ssl/certs/ca-certificates.crt
+            type: File
+
+      # We really only want linux nodes (this is of no use for Windows nodes)
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+{{- end }}

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -1,0 +1,49 @@
+# Some default values for the Kamino VMSS-Prototype Pattern Image Generator
+
+kamino:
+  name: kamino-gen
+  labels:
+    app: kamino-vmss-prototype
+  container:
+    # TODO:  Point these to our public container registry once we have it setup
+    imageRegistry: some.acr.io
+    imageRepository: some/path/kamino/vmss-prototype
+    imageTag: testing
+    # Pulling by has is stronger assurance that things are not changed
+    #imageHash: "xxx"
+    # Since we don't define a hash here, set this to false
+    pullByHash: false
+
+    # include the name of the image pull secret in your cluster if you
+    # need one.  (Note that they are local to the namespace you deploy in)
+    #pullSecret: skyman-acr
+
+  # Number of images to keep in the history
+  # Minimum is 2.
+  imageHistory: 3
+
+  drain:
+    # Drain grace period is the maximum time to allow pods to drain load
+    # and leave the node.  The default of 300 seconds is relatively long
+    # but extra safe.
+    gracePeriod: 300
+
+    # Drain Force, if set to true, will force drain the node if the normal
+    # drain fails to drain the node.  This may be needed if the drain operation
+    # is not respected by the workloads in the cluster.
+    force: false
+
+  # This is the log-level for the process via python logging.
+  # Each level includes all below it, so DEBUG includes INFO, WARNING, etc...
+  # Best keep this at INFO
+
+  # DEBUG    - Very verbose (albeit not that much more than INFO)
+  # INFO     - Show all process executions and actions as progress
+  # WARNING  - Show only the warnings
+  # ERROR    - Show only the errors
+  # CRITICAL - Show only complete critical faults
+  logLevel: INFO
+
+  # The cluster name and the target node are not things we can know
+  # automatically
+  #targetNode: k8s-agentpool1-12345678-vmss0001ct

--- a/vmss-prototype/smoketest.sh
+++ b/vmss-prototype/smoketest.sh
@@ -18,10 +18,10 @@ if [[ ! -z ${KUBECONFIG} ]] &&
    [[ -d ${HOME}/.azure ]]
    then
         docker run --rm -i -t \
-            -v $(which kubectl):/usr/bin/kubectl:ro \
             -u ${UID}:${GID} \
-            -v ${HOME}/.azure:${HOME}/.azure \
-            -v ${KUBECONFIG}:${KUBECONFIG}:ro \
+            --mount type=bind,source=$(which kubectl),target=/usr/bin/kubectl,readonly \
+            --mount type=bind,source=${HOME}/.azure,target=${HOME}/.azure \
+            --mount type=bind,source=${KUBECONFIG},target=${KUBECONFIG},readonly \
             -e USER=${USER} \
             -e HOME=${HOME} \
             -e KUBECONFIG=${KUBECONFIG} \

--- a/vmss-prototype/smoketest.sh
+++ b/vmss-prototype/smoketest.sh
@@ -13,6 +13,7 @@ docker run --rm -i -t ${IMAGE_TAG} --help
 # When run in the cluster, other mechanisms would be used
 if [[ ! -z ${KUBECONFIG} ]] &&
    [[ ! -z ${CLUSTER_NAME} ]] &&
+   [[ ! -z ${RESOURCE_GROUP} ]] &&
    [[ ! -z ${AZ_SUB} ]] &&
    [[ -f ${KUBECONFIG} ]] &&
    [[ -d ${HOME}/.azure ]]
@@ -28,6 +29,6 @@ if [[ ! -z ${KUBECONFIG} ]] &&
             ${IMAGE_TAG} \
             status \
                 --name ${CLUSTER_NAME} \
-                --resource-group SCM__${CLUSTER_NAME} \
+                --resource-group ${RESOURCE_GROUP} \
                 --subscription ${AZ_SUB}
 fi

--- a/vmss-prototype/smoketest.sh
+++ b/vmss-prototype/smoketest.sh
@@ -12,7 +12,6 @@ docker run --rm -i -t ${IMAGE_TAG} --help
 # the resource group name so I can test like this.  Others may not)
 # When run in the cluster, other mechanisms would be used
 if [[ ! -z ${KUBECONFIG} ]] &&
-   [[ ! -z ${CLUSTER_NAME} ]] &&
    [[ ! -z ${RESOURCE_GROUP} ]] &&
    [[ ! -z ${AZ_SUB} ]] &&
    [[ -f ${KUBECONFIG} ]] &&
@@ -28,7 +27,6 @@ if [[ ! -z ${KUBECONFIG} ]] &&
             -e KUBECONFIG=${KUBECONFIG} \
             ${IMAGE_TAG} \
             status \
-                --name ${CLUSTER_NAME} \
                 --resource-group ${RESOURCE_GROUP} \
                 --subscription ${AZ_SUB}
 fi

--- a/vmss-prototype/smoketest2.sh
+++ b/vmss-prototype/smoketest2.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -e
+
+MY_ACR=skyman.azurecr.io
+MY_REPOSITORY=scratch/kamino/vmss-prototype
+MY_TAG=experimental.msinz
+
+az acr login -n ${MY_ACR}
+
+IMAGE_TAG=${MY_ACR}/${MY_REPOSITORY}:${MY_TAG}
+
+docker build . -t ${IMAGE_TAG}
+
+docker run --rm -i -t ${IMAGE_TAG} --help
+
+docker push ${IMAGE_TAG}
+
+# The helm binary - I use helm3 as the name as we had to support both in the past
+HELM3=helm3
+
+# Get rid of any prior version (just in case)
+${HELM3} delete smoke-test 2>/dev/null >/dev/null || true
+
+# This is my smoke-test.  I force the gracePeriod to be short
+# and that we will move forward even if drain fails just because
+# I am not testing kubectl drain or the pod disruption budgets here
+# It also shows how you can override these values.  Normally, one
+# would not want to "force" a drain unless you knew that all services
+# on that node were expendable at the time.
+# The commented out targetNode setting shows an example of that for
+# my test cluster.  If it is not included, this runs as a status
+# job.  If a target node is included, it runs as an actual image
+# creation job.
+${HELM3} upgrade --install smoke-test ../helm/vmss-prototype \
+    --namespace default \
+    --set kamino.name=kamino-smoketest \
+    --set kamino.container.imageRegistry=${MY_ACR} \
+    --set kamino.container.imageRepository=${MY_REPOSITORY} \
+    --set kamino.container.imageTag=${MY_TAG} \
+    --set kamino.container.pullByHash=false \
+    --set kamino.container.pullSecret=skyman-acr \
+    --set kamino.drain.gracePeriod=5 \
+    --set kamino.drain.force=true \
+    #--set kamino.targetNode=k8s-agentpool1-18861755-vmss000007
+
+kubectl get jobs -lapp=kamino-vmss-prototype
+
+# Note that I do this here knowing that it will never exit and that
+# I am just watching it start/etc.  That was the whole point.
+kubectl get pods -o wide -lapp=kamino-vmss-prototype -w

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -829,8 +829,8 @@ def ClusterName(v):
     :param v: The proposed cluster name
     :return: The cluster name if it fits within naming constraints
     """
-    if re.match(r'^[0-9a-zA-Z-]{1,18}$', v) is None:
-        raise argparse.ArgumentTypeError("Cluster names must be 1 to 18 characters of A-Z, a-z, 0-9, or -")
+    if re.match(r'^[0-9a-zA-Z-]+$', v) is None:
+        raise argparse.ArgumentTypeError("Cluster names must consist of characters A-Z, a-z, 0-9, or -")
     return v
 
 

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -278,7 +278,7 @@ def get_sig_image_def(vmss_name):
     :param vmss_name:  The name of the VMSS we are looking for
     :return:  Name of the SIG image definiton
     """
-    return 'Skyman-{0}-prototype'.format(vmss_name)
+    return 'kamino-{0}-prototype'.format(vmss_name)
 
 
 def convert_os_patch_datetime(patch_time):
@@ -350,7 +350,7 @@ def vmss_prototype_collect_status(sub_args):
                    '--gallery-name', sig_name
                    ], retries=3, check=False, retry_func=not_found_no_retry)
     if rc != 0:
-        yield '{0}: No Skyman VMSS Prototype Shared Image Gallery for cluster'.format(sub_args.name)
+        yield '{0}: No Kamino VMSS Prototype Shared Image Gallery for cluster'.format(sub_args.name)
         return
 
     for vmss in get_vmss_set():
@@ -363,7 +363,7 @@ def vmss_prototype_collect_status(sub_args):
                             '--gallery-image-definition', image_definition
                             ], retries=3, check=False, retry_func=not_found_no_retry)
         if rc != 0:
-            yield '{0}: {1}: No Skyman VMSS Prototype Image Definition'.format(sub_args.name, vmss)
+            yield '{0}: {1}: No Kamino VMSS Prototype Image Definition'.format(sub_args.name, vmss)
             continue
 
         image_def = json.loads(output)
@@ -374,12 +374,12 @@ def vmss_prototype_collect_status(sub_args):
                             '--gallery-image-definition', image_definition
                             ], retries=3, check=False, retry_func=not_found_no_retry)
         if rc != 0:
-            yield '{0}: {1}: Failed to get Skyman VMSS Prototype Image Definition Versions'.format(sub_args.name, vmss)
+            yield '{0}: {1}: Failed to get Kamino VMSS Prototype Image Definition Versions'.format(sub_args.name, vmss)
             continue
 
         versions = json.loads(output)
         if len(versions) < 1:
-            yield '{0}: {1}: No Skyman VMSS Prototype Image Definition Versions'.format(sub_args.name, vmss)
+            yield '{0}: {1}: No Kamino VMSS Prototype Image Definition Versions'.format(sub_args.name, vmss)
             continue
 
         output, _, _ = run(az(['vmss', 'show'], subscription) + [
@@ -525,7 +525,7 @@ def vmss_prototype_update(sub_args):
         run(az(['sig', 'create'], subscription) + [
             '--resource-group', resource_group,
             '--gallery-name', sig_name,
-            '--description', 'Skyman VMSS images'
+            '--description', 'Kamino VMSS images'
             ], retries=3)
 
     # Pod types we will skip during drain/delete

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -23,7 +23,7 @@ def fatal_error(msg):
     :param msg: Message to be output
     :return: None
     """
-    logging.error(msg)
+    logging.critical(msg)
     sys.stderr.write('{0}\n'.format(msg))
     sys.stderr.flush()
     sys.exit(-1)
@@ -36,11 +36,11 @@ def masq_text(text, masq=None):
     :param masq: List of strings to masquerade from the output log (useful for secrets)
     :return: The text string after masquerading secrets
     """
-    masq_text = str(text)
+    m_text = str(text)
     if masq is not None:
         for masq_item in masq:
-            masq_text = masq_text.replace(masq_item.decode() if isinstance(masq_item, bytes) else masq_item, '***')
-    return masq_text
+            m_text = m_text.replace(masq_item.decode() if isinstance(masq_item, bytes) else masq_item, '***')
+    return m_text
 
 
 def masq_cmd(command, masq=None):
@@ -262,14 +262,16 @@ def get_vmss_set():
     return sorted({node_to_vmss(node) for node in get_nodes() if is_vmss_node(node)})
 
 
-def get_vmss_sig(cluster_name):
+def get_vmss_sig(name):
     """
-    Return the name of the SIG for a given cluster name
-    :param cluster_name: The name of the cluster
+    Return the name of the SIG for a given unique name (usually the resource group name)
+    :param name: The unique name, usually of the resource group
     :return: The name of the SIG for that cluster
     """
     # SIG names can not have "-" but can have "_"
-    return 'SIG_{0}'.format(cluster_name.replace('-','_'))
+    # SIG names also must be unique across the subscription even if
+    # they are within different resource groups!
+    return 'SIG_{0}'.format(name.replace('-','_'))
 
 
 def get_sig_image_def(vmss_name):
@@ -343,14 +345,14 @@ def vmss_prototype_collect_status(sub_args):
     """
     subscription = sub_args.subscription
     resource_group = sub_args.resource_group
-    sig_name = get_vmss_sig(sub_args.name)
+    sig_name = get_vmss_sig(resource_group)
 
     _, _, rc = run(az(['sig', 'show'], subscription) + [
                    '--resource-group', resource_group,
                    '--gallery-name', sig_name
                    ], retries=3, check=False, retry_func=not_found_no_retry)
     if rc != 0:
-        yield '{0}: No Kamino VMSS Prototype Shared Image Gallery for cluster'.format(sub_args.name)
+        yield 'No Kamino VMSS Prototype Shared Image Gallery for cluster'
         return
 
     for vmss in get_vmss_set():
@@ -363,7 +365,7 @@ def vmss_prototype_collect_status(sub_args):
                             '--gallery-image-definition', image_definition
                             ], retries=3, check=False, retry_func=not_found_no_retry)
         if rc != 0:
-            yield '{0}: {1}: No Kamino VMSS Prototype Image Definition'.format(sub_args.name, vmss)
+            yield '{0}: {1}: No Kamino VMSS Prototype Image Definition'.format(sub_args.resource_group, vmss)
             continue
 
         image_def = json.loads(output)
@@ -374,12 +376,12 @@ def vmss_prototype_collect_status(sub_args):
                             '--gallery-image-definition', image_definition
                             ], retries=3, check=False, retry_func=not_found_no_retry)
         if rc != 0:
-            yield '{0}: {1}: Failed to get Kamino VMSS Prototype Image Definition Versions'.format(sub_args.name, vmss)
+            yield '{0}: {1}: Failed to get Kamino VMSS Prototype Image Definition Versions'.format(sub_args.resource_group, vmss)
             continue
 
         versions = json.loads(output)
         if len(versions) < 1:
-            yield '{0}: {1}: No Kamino VMSS Prototype Image Definition Versions'.format(sub_args.name, vmss)
+            yield '{0}: {1}: No Kamino VMSS Prototype Image Definition Versions'.format(sub_args.resource_group, vmss)
             continue
 
         output, _, _ = run(az(['vmss', 'show'], subscription) + [
@@ -391,7 +393,7 @@ def vmss_prototype_collect_status(sub_args):
         versions.sort(key=lambda image: image['name'])
         for version in reversed(versions):
             yield '{0}: {1}: VMSS Prototype Image Version {2} - {3} - BuiltFrom: {4} @ {5}'.format(
-                sub_args.name,
+                sub_args.resource_group,
                 vmss,
                 lookup_one_value(version, 'name'),
                 lookup_one_value(version, 'provisioningState'),
@@ -402,16 +404,16 @@ def vmss_prototype_collect_status(sub_args):
         image_ref = lookup_one_value(vmss_info, 'virtualMachineProfile.storageProfile.imageReference.id')
         found = False
         if image_ref == image_def['id']:
-            yield '{0}: {1}: Configured to use latest VMSS Prototype Image Definition'.format(sub_args.name, vmss)
+            yield '{0}: {1}: Configured to use latest VMSS Prototype Image Definition'.format(sub_args.resource_group, vmss)
             found = True
         else:
             for version in versions:
                 if image_ref == version['id']:
-                    yield '{0}: {1}: Configured to use VMSS Prototype Image Version {2}'.format(sub_args.name, vmss, version['name'])
+                    yield '{0}: {1}: Configured to use VMSS Prototype Image Version {2}'.format(sub_args.resource_group, vmss, version['name'])
                     found = True
 
         if not found:
-            yield '{0}: {1}: Not configured to use VMSS Prototype Image'.format(sub_args.name, vmss)
+            yield '{0}: {1}: Not configured to use VMSS Prototype Image'.format(sub_args.resource_group, vmss)
 
 
 def vmss_prototype_status(sub_args):
@@ -420,9 +422,12 @@ def vmss_prototype_status(sub_args):
     :param sub_args:  Command line arguments
     :return:
     """
+    if not sub_args.resource_group:
+        fatal_error('Must provide the resource group of the cluster!')
+
     # Gather the results and then print them
     results = list(vmss_prototype_collect_status(sub_args))
-    print('VMSS Prototype Status for cluster {0}:'.format(sub_args.name))
+    print('VMSS Prototype Status for cluster:')
     for result in results:
         print(result)
 
@@ -503,10 +508,13 @@ def vmss_prototype_update(sub_args):
     :param sub_args:  Arguments from command line
     :return:
     """
-    subscription = sub_args.subscription
     resource_group = sub_args.resource_group
-    sig_name = get_vmss_sig(sub_args.name)
+    if not resource_group:
+        fatal_error('Must provide the resource group of the cluster!')
+
+    subscription = sub_args.subscription
     target_node = sub_args.target_node
+    sig_name = get_vmss_sig(resource_group)
 
     # Check if the target node exists
     _, _, rc = run(['kubectl', 'get', 'node',
@@ -563,7 +571,7 @@ def vmss_prototype_update(sub_args):
                            '--gallery-name', sig_name,
                            '--gallery-image-definition', image_definition,
                            '--publisher', 'VMSS-Prototype-Pattern',
-                           '--offer', sub_args.name,
+                           '--offer', sub_args.resource_group,
                            '--sku', vmss,
                            '--os-type', 'Linux',
                            '--os-state', 'generalized'
@@ -658,7 +666,7 @@ def vmss_prototype_update(sub_args):
                                 '--grace-period', sub_args.grace_period,
                                 '--timeout', '{0}s'.format(sub_args.grace_period * 3),
                                 target_node
-                                ], check=False, retries=2, timeout=60 + sub_args.grace_period * 9)
+                                ], check=False, retries=2, log_timing=True, timeout=60 + sub_args.grace_period * 9)
 
                 if rc != 0:
                     if not sub_args.force:
@@ -685,7 +693,7 @@ def vmss_prototype_update(sub_args):
                     '--resource-group', resource_group,
                     '--name', vmss,
                     '--instance-ids', instance_id
-                    ], retries=3, retry_func=not_found_no_retry)
+                    ], retries=3, log_timing=True, retry_func=not_found_no_retry)
 
                 # Snapshot the disk
                 output, _, _ = run(az(['snapshot', 'create'], subscription) + [
@@ -823,15 +831,100 @@ def vmss_prototype_update(sub_args):
                 ], retries=3, check=False, retry_func=not_found_no_retry)
 
 
-def ClusterName(v):
-    """
-    Cluster Name validation type for argparser ( 1 to 18 characters of A-Z/a-z/0-9/- )
-    :param v: The proposed cluster name
-    :return: The cluster name if it fits within naming constraints
-    """
-    if re.match(r'^[0-9a-zA-Z-]+$', v) is None:
-        raise argparse.ArgumentTypeError("Cluster names must consist of characters A-Z, a-z, 0-9, or -")
-    return v
+def in_cluster(sub_args, func):
+    '''
+    Check for in-cluster behavior and do the that to set up some values in the
+    arguments before calling the given func
+    :param sub_args: The sub_args as given from the command line
+    :param func: The function to complete the operation
+    '''
+    if sub_args.in_cluster:
+        with open('/etc/kubernetes/azure.json', 'r') as azure_json_file:
+            data = json.load(azure_json_file)
+        username = data['aadClientId']
+        password = data['aadClientSecret']
+        tenant = data['tenantId']
+        subscription = data['subscriptionId']
+        resource_group = data['resourceGroup']
+
+        # We have to set our default cloud (the public cloud is the default-default)
+        cloud = data['cloud']
+
+        # NOTE!  We have some remapping needs of the cloud name.
+        #        The problem is that the cloud name as stored in this json does
+        #        not match the cloud name that is used by azure CLI!
+        # NOTE!  'AzurePublicCloud' must be mapped to 'AzureCloud'
+        # NOTE!  'AzureUSGovernmentCloud' must be mapped to 'AzureUSGovernment'
+        remapping = {
+            'AzurePublicCloud': 'AzureCloud',
+            'AzureUSGovernmentCloud': 'AzureUSGovernment'
+        }
+        cloud = remapping.get(cloud, cloud)
+
+        # For air-gapped clouds, CustomCloudProfile needs to be specified in api-model
+        # when CustomCloudProfile is specified in api-model, aks engine produces azure.json
+        # with "cloud":"AzureStackCloud" and azurestackcloud.json with cloud name specified
+        # in the CustomCloudProfile
+        # https://github.com/Azure/aks-engine/pull/3063
+
+        if cloud == "AzureStackCloud":
+            with open('/etc/kubernetes/azurestackcloud.json', 'r') as azurestackfile:
+                azurestackdata = json.load(azurestackfile)
+
+            cloud = azurestackdata['name']
+
+            # check if custom cloud is already registered
+            registered_cloud, _, _ = run(["az", "cloud", "list",
+                                          "--output", "tsv",
+                                          "--query", "[?@.name == '{0}'].name".format(cloud)
+                                          ])
+
+            # registered_cloud comes with trainling white space, so remove it
+            if registered_cloud.strip() != cloud:
+                # cloud is not registered
+                # Register the cloud
+                run(['az', 'cloud', 'register',
+                     '--name', cloud,
+                     '--endpoint-active-directory', azurestackdata['activeDirectoryEndpoint'],
+                     '--endpoint-active-directory-graph-resource-id', azurestackdata['graphEndpoint'],
+                     '--endpoint-active-directory-resource-id', azurestackdata['resourceManagerEndpoint'],
+                     '--endpoint-management', azurestackdata['serviceManagementEndpoint'],
+                     '--endpoint-resource-manager', azurestackdata['resourceManagerEndpoint'],
+                     '--suffix-acr-login-server-endpoint', azurestackdata['containerRegistryDNSSuffix'],
+                     '--suffix-keyvault-dns', azurestackdata['keyVaultDNSSuffix'],
+                     '--suffix-storage-endpoint', azurestackdata['storageEndpointSuffix']
+                     ])
+
+        run(['az', 'cloud', 'set',
+             '--name', cloud
+             ])
+
+        login_cmd = ['az', 'login',
+                    '--username', username,
+                    '--password', password,
+                    '--tenant', tenant,
+                    '--service-principal'
+                    ]
+        masq = [username, password, tenant]
+
+        # We have seen temporary network failures cause this to fail so we will
+        # add a simple retry loop here, with slowly increasing delay between
+        # each retry.
+        run(['az', 'login',
+             '--username', username,
+             '--password', password,
+             '--tenant', tenant,
+             '--service-principal'
+             ], retries=10, masq=masq, retry_wait_duration_func=lambda num_retry: 5 * num_retry + 1)
+
+        run(['az', 'account', 'set',
+             '--subscription', subscription
+             ])
+
+        sub_args.subscription = subscription
+        sub_args.resource_group = resource_group
+
+    return func(sub_args)
 
 
 def NodeName(v):
@@ -879,16 +972,18 @@ def add_command(subparsers, command, func, description=None):
     :return: The parser for the command that was added
     """
     parser = subparsers.add_parser(command, description=description, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("-n", "--name", required=True, type=ClusterName,
-                        help="Name of the cluster (required)")
-    parser.add_argument("-g", "--resource-group", required=True,
-                        help="Name of the resource group the cluster is in (required)")
+    parser.set_defaults(func=lambda sub_args: in_cluster(sub_args, func))
+
+    # We need the resource group of the cluster.  When --in-cluster, this is
+    # discovered from the azure.json cluster definition file on the node
+    parser.add_argument("-g", "--resource-group", default=None,
+                        help="Name of the resource group the cluster is in (required if not --in-cluster)")
+
     # We take a subscription in case the user has access to more than one in the
-    # az cli - since we need to pick the right subscription.  We could talk about
-    # assuming that the correct subscription is already set as default.
+    # az cli - since we need to pick the right subscription.  When --in-cluster,
+    # this is discovered from the azure.json cluster definition file on the node
     parser.add_argument("-s", "--subscription", default=None, type=SubscriptionId,
-                        help="The subscription guid for the cluster's resource group")
-    parser.set_defaults(func=func)
+                        help="The subscription guid for the cluster's resource group (required if not --in-cluster)")
 
     return parser
 
@@ -976,6 +1071,9 @@ def main():
 
     parser.add_argument('--log-timestamps', default=False, action='store_true',
                         help='Include timestamps in the logging output')
+
+    parser.add_argument("--in-cluster", default=False, action='store_true',
+                        help="Use azure.json to set up state (including subscription, resource group, and azure access)")
 
     subparser = parser.add_subparsers(title="commands")
 

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -255,8 +255,8 @@ def node_to_vmss(node_name):
 
 def get_vmss_set():
     """
-    Get the sorted list of VMSS that could be set to run prototype model
-    :return: A set of valid VMSS for this cluster that could run prototype model
+    Get the sorted list of VMSS that could be set to run prototype pattern
+    :return: A set of valid VMSS for this cluster that could run prototype pattern
     """
     # The set of VMSS in the cluster
     return sorted({node_to_vmss(node) for node in get_nodes() if is_vmss_node(node)})
@@ -995,7 +995,7 @@ def register_commands(subparser):
     :return: True if the command was added
     """
     parser = add_command(subparser, "status", func=vmss_prototype_status,
-                         description='Show status of VMSS Prototype model')
+                         description='Show status of VMSS Prototype Pattern')
 
     parser = add_command(subparser, "update", func=vmss_prototype_update,
                          description='Set up new/updated prototype')
@@ -1059,9 +1059,9 @@ def main():
         description="VMSS Prototype Pattern Tool",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="\nexample use: \n\
-  vmss-prototype.py status ...\n\n\
+  {0} status ...\n\n\
   More information available here: https://speechwiki.azurewebsites.net/architecture/skyman-vmss-prototype-pattern.html\n\
-    "
+    ".format(sys.argv[0])
     )
 
     # Log level settings happen at the global level


### PR DESCRIPTION
Now there is a working helm chart plus some refactoring to allow for the fact that we don't need the cluster name (nor are able to get it from the azure.json in the cluster).

Also includes a merge of the renaming of some items and messages.

NOTE:  This changes the name of the Shared Image Gallery so it will not touch the older ones.  It will move the VMSS to the new image gallery when you do an update.  This should (hopefully) be the last time we do the SIG renaming.   But things work fine even if we do, just that the old SIG is never touched again.