### PR TITLE
ci: use docker/build-push-action for image pushes

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -31,7 +31,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          file: 'vmss-prototype/Dockerfile'
+          context: './vmss-prototype'
+          file: './Dockerfile'
           tags: |
             ghcr.io/jackfrancis/kamino:${{ env.RELEASE_VERSION }}
             ghcr.io/jackfrancis/kamino:latest

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -24,5 +24,5 @@ jobs:
           push: true
           file: 'vmss-prototype/Dockerfile'
           tags: |
-            ghcr.io/owner/templated-repo:${{ env.RELEASE_VERSION }}
-            ghcr.io/owner/templated-repo:latest
+            ghcr.io/jackfrancis/kamino:${{ env.RELEASE_VERSION }}
+            ghcr.io/jackfrancis/kamino:latest

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,28 @@
+name: release image
+on:
+  push:
+    tags:
+      - 'image-v*' # push events for tags matching image-v for version (image-v1.0, etc)
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: set env
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:17}) # refs/tags/image-v1.0.0 substring starting at 1.0.0
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v1
+      - name: login to GitHub container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: 'vmss-prototype/Dockerfile'
+          tags: |
+            ghcr.io/owner/templated-repo:${{ env.RELEASE_VERSION }}
+            ghcr.io/owner/templated-repo:latest

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -3,6 +3,11 @@ on:
   push:
     tags:
       - 'image-v*' # push events for tags matching image-v for version (image-v1.0, etc)
+  workflow_dispatch:
+    inputs:
+      test_version:
+        description: 'Test image version to push'
+        required: true
 jobs:
   image:
     runs-on: ubuntu-latest
@@ -10,6 +15,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: set env
         run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:17}) # refs/tags/image-v1.0.0 substring starting at 1.0.0
+        if: ${{github.event.inputs.test_version == ""}}
+      - name: set env
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${{test_version}}-canary)
+        if: ${{github.event.inputs.test_version != ""}}
       - name: setup buildx
         uses: docker/setup-buildx-action@v1
       - name: login to GitHub container registry


### PR DESCRIPTION
This PR delivers a "release-image" github action workflow to automatically publish 