### PR TITLE
fix: github.event.inputs.test_version in Actions spec

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:17}) # refs/tags/image-v1.0.0 substring starting at 1.0.0
         if: ${{github.event.inputs.test_version == ''}}
       - name: set env
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${{test_version}}-canary)
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${{github.event.inputs.test_version}}-canary)
         if: ${{github.event.inputs.test_version != ''}}
       - name: setup buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Ref:

```
The workflow is not valid. .github/workflows/release-image.yml (Line: 20, Col: 14): Unrecognized named-value: 'test_version'. Located at position 1 within expression: test_version
```