### PR TITLE
fix: set-env is deprecated

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: set env
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:17}) # refs/tags/image-v1.0.0 substring starting at 1.0.0
+        run: echo "RELEASE_VERSION=${GITHUB_REF:17}" >> $GITHUB_ENV # refs/tags/image-v1.0.0 substring starting at 1.0.0
         if: ${{github.event.inputs.test_version == ''}}
       - name: set env
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${{github.event.inputs.test_version}}-canary)
+        run: echo "RELEASE_VERSION=${{github.event.inputs.test_version}}-canary" >> $GITHUB_ENV
         if: ${{github.event.inputs.test_version != ''}}
       - name: setup buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Ref:

```
The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```