### PR TITLE
fix: use vmss-protype in path for Action

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -31,8 +31,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          context: './vmss-prototype'
-          file: './Dockerfile'
+          context: vmss-prototype
+          file: vmss-prototype/Dockerfile
           tags: |
             ghcr.io/jackfrancis/kamino:${{ env.RELEASE_VERSION }}
             ghcr.io/jackfrancis/kamino:latest


### PR DESCRIPTION
Examples online suggest you want to include the relative directory path as the context value, and also to use it in the file definition.

E.g.:

https://stackoverflow.com/questions/63887031/build-docker-image-locally-in-github-actions-using-docker-build-push-action