### PR TITLE
ci: remove vmss-prototype context from release-image action

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -31,7 +31,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          context: vmss-prototype
           file: vmss-prototype/Dockerfile
           tags: |
             ghcr.io/jackfrancis/kamino:${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
I'm not sure we need this context config, and I wonder if it's conflicting with the docker/login-action config.