### PR TITLE
ci: use 'vmss-prototype' as the image name

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -33,5 +33,5 @@ jobs:
           push: true
           file: vmss-prototype/Dockerfile
           tags: |
-            ghcr.io/jackfrancis/kamino:${{ env.RELEASE_VERSION }}
-            ghcr.io/jackfrancis/kamino:latest
+            ghcr.io/jackfrancis/kamino/vmss-prototype:${{ env.RELEASE_VERSION }}
+            ghcr.io/jackfrancis/kamino/vmss-prototype:latest


### PR DESCRIPTION
This PR names the ghcr.io-hosted image "vmss-prototype".