### PR TITLE
feat: enable vmss-prototype in MSI context

### DIFF
--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -900,13 +900,14 @@ def in_cluster(sub_args, func):
              ])
 
         login_cmd = ['az', 'login',
-                        '--username', username,
-                        '--password', password,
-                        '--tenant', tenant,
-                        '--service-principal'
-                        ]
+                    '--username', username,
+                    '--password', password,
+                    '--tenant', tenant,
+                    '--service-principal'
+                    ]
         if username == "msi":
             login_cmd = ['az', 'login', '--identity']
+        masq = [username, password, tenant]
 
         # We have seen temporary network failures cause this to fail so we will
         # add a simple retry loop here, with slowly increasing delay between

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -899,23 +899,30 @@ def in_cluster(sub_args, func):
              '--name', cloud
              ])
 
-        login_cmd = ['az', 'login',
-                    '--username', username,
-                    '--password', password,
-                    '--tenant', tenant,
-                    '--service-principal'
-                    ]
+        if username == "msi":
+            login_cmd = ['az', 'login', '--identity']
+        else:
+            login_cmd = ['az', 'login',
+                        '--username', username,
+                        '--password', password,
+                        '--tenant', tenant,
+                        '--service-principal'
+                        ]
         masq = [username, password, tenant]
 
         # We have seen temporary network failures cause this to fail so we will
         # add a simple retry loop here, with slowly increasing delay between
         # each retry.
-        run(['az', 'login',
-             '--username', username,
-             '--password', password,
-             '--tenant', tenant,
-             '--service-principal'
-             ], retries=10, masq=masq, retry_wait_duration_func=lambda num_retry: 5 * num_retry + 1)
+        if username == "msi":
+            run(['az', 'login', '--identity'
+            ], retries=10, masq=masq, retry_wait_duration_func=lambda num_retry: 5 * num_retry + 1])
+        else:
+            run(['az', 'login',
+                '--username', username,
+                '--password', password,
+                '--tenant', tenant,
+                '--service-principal'
+                ], retries=10, masq=masq, retry_wait_duration_func=lambda num_retry: 5 * num_retry + 1)
 
         run(['az', 'account', 'set',
              '--subscription', subscription

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -899,30 +899,19 @@ def in_cluster(sub_args, func):
              '--name', cloud
              ])
 
-        if username == "msi":
-            login_cmd = ['az', 'login', '--identity']
-        else:
-            login_cmd = ['az', 'login',
+        login_cmd = ['az', 'login',
                         '--username', username,
                         '--password', password,
                         '--tenant', tenant,
                         '--service-principal'
                         ]
-        masq = [username, password, tenant]
+        if username == "msi":
+            login_cmd = ['az', 'login', '--identity']
 
         # We have seen temporary network failures cause this to fail so we will
         # add a simple retry loop here, with slowly increasing delay between
         # each retry.
-        if username == "msi":
-            run(['az', 'login', '--identity'
-            ], retries=10, masq=masq, retry_wait_duration_func=lambda num_retry: 5 * num_retry + 1])
-        else:
-            run(['az', 'login',
-                '--username', username,
-                '--password', password,
-                '--tenant', tenant,
-                '--service-principal'
-                ], retries=10, masq=masq, retry_wait_duration_func=lambda num_retry: 5 * num_retry + 1)
+        run(login_cmd, retries=10, masq=masq, retry_wait_duration_func=lambda num_retry: 5 * num_retry + 1])
 
         run(['az', 'account', 'set',
              '--subscription', subscription


### PR DESCRIPTION
This PR enables `az login` functionality when node VMs are wired up for MSI (user- or system-assigned identity).