### PR TITLE
chore: update helm metadata

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -5,9 +5,11 @@ version: 0.0.1
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com
-home: https://speechwiki.azurewebsites.net/architecture/skyman-vmss-prototype-pattern.html
+  - name: Jack Francis
+    email: jackfrancis@gmail.com
+home: https://github.com/jackfrancis/kamino/README.md
 sources:
-  - https://github.com/Michael-Sinz/kamino
+  - https://github.com/jackfrancis/kamino
 keywords:
   - vmss
   - azure

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -6,9 +6,9 @@ kamino:
     app: kamino-vmss-prototype
   container:
     # TODO:  Point these to our public container registry once we have it setup
-    imageRegistry: some.acr.io
-    imageRepository: some/path/kamino/vmss-prototype
-    imageTag: testing
+    imageRegistry: ghcr.io
+    imageRepository: jackfrancis/kamino/vmss-prototype
+    imageTag: latest
     # Pulling by has is stronger assurance that things are not changed
     #imageHash: "xxx"
     # Since we don't define a hash here, set this to false


### PR DESCRIPTION
This PR updates the vmss-prototype helm Chart metadata to reference the actual canonical ghcr.io container image, and some other housekeeping.