### PR TITLE
feat: allow "force schedule on control plane VM"

### DIFF
--- a/helm/vmss-prototype/templates/vmss-prototype.yaml
+++ b/helm/vmss-prototype/templates/vmss-prototype.yaml
@@ -126,7 +126,17 @@ spec:
             path: /etc/ssl/certs/ca-certificates.crt
             type: File
 
+      # Tolerate the AKS Engine control plane taint, to accommodate clusters with only one VMSS node
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
       # We really only want linux nodes (this is of no use for Windows nodes)
       nodeSelector:
+        # Optionally, require scheduling the pod onto a control plane VM using the AKS Engine control plane VM identifier
+        {{- if .Values.kamino.scheduleOnControlPlane }}
+        kubernetes.io/role: master
+        {{- end }}
         beta.kubernetes.io/os: linux
 {{- end }}

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -47,3 +47,7 @@ kamino:
   # The cluster name and the target node are not things we can know
   # automatically
   #targetNode: k8s-agentpool1-12345678-vmss0001ct
+
+  # Require scheduling the pod onto a control plane VM using the AKS Engine control plane VM identifier
+  # Default to false, which allows scheduling on any node other than the targetNode
+  scheduleOnControlPlane: false


### PR DESCRIPTION
This PR adds a `scheduleOnControlPlane` boolean flag to the helm chart, to allow forcing the vmss-prototype runtime to be scheduled onto a control plane VM, using the AKS Engine-created `kubernetes.io/role=master` node label. E.g.:

`$ helm upgrade --install vmss-prototype helm/vmss-prototype --namespace default --set kamino.scheduleOnControlPlane=true --set kamino.targetNode=<target node>`

Also, we add a toleration for the AKS Engine-created `node-role.kubernetes.io/master=true:NoSchedule` control plane node taint. That toleration unblocks the above new feature to force scheduling onto a control plane VM, as well as permits scheduling to a control plane VM if in fact that is the best available node candidate on the cluster (e.g., if there is only one node in the cluster, and it's the target node, or if there is no available pod density on all worker nodes in the cluster).