### PR TITLE
chore: use explicit charts_dir for helm repo action

### DIFF
--- a/.github/workflows/publish-helm-repo.yml
+++ b/.github/workflows/publish-helm-repo.yml
@@ -23,5 +23,7 @@ jobs:
           version: v3.4.0
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0
+        with:
+          charts_dir: /helm
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR attempts to wrangle the chart-releaser into "action" by specifying the "/helm" charts_dir.