### PR TITLE
feat: delete prototype candidate instance, add 1 new instance

### DIFF
--- a/helm/vmss-prototype/templates/vmss-prototype.yaml
+++ b/helm/vmss-prototype/templates/vmss-prototype.yaml
@@ -65,6 +65,8 @@ spec:
             - update
             - --target-node
             - {{ .Values.kamino.targetNode | quote }}
+            -- new-updated-nodes
+            - {{ .Values.kamino.newUpdatedNodes | quote }}
             - --grace-period
             - {{ required "missing required kamino.drain.gracePeriod" .Values.kamino.drain.gracePeriod | quote }}
             - --max-history

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -48,6 +48,8 @@ kamino:
   # automatically
   #targetNode: k8s-agentpool1-12345678-vmss0001ct
 
+  # Set newUpdatedNodes to a higher value to immediately add more nodes built from the prototype after VMSS update is complete
+  newUpdatedNodes: 0
   # Require scheduling the pod onto a control plane VM using the AKS Engine control plane VM identifier
   # Default to false, which allows scheduling on any node other than the targetNode
   scheduleOnControlPlane: false

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -14,7 +14,7 @@ import sys
 import time
 
 # This is what hooks to the Python bash autocomplete
-import argcomplete # type: ignore
+import argcomplete  # type: ignore
 
 
 def fatal_error(msg):
@@ -706,10 +706,9 @@ def vmss_prototype_update(sub_args):
                                    ], retries=6)
                 snapshot = json.loads(output)
 
-                # Start it up again now that we have the snapshot
-                # We ignore errors here since it is possible that
-                # someone deleted the VM after the snapshot
-                run(az(['vmss', 'start'], subscription) + [
+                # Delete the instance to prevent idns side-effects from future VMs coming online based on its prototype
+                # See https://github.com/jackfrancis/kamino/issues/26
+                run(az(['vmss', 'delete-instances'], subscription) + [
                     '--resource-group', resource_group,
                     '--name', vmss,
                     '--instance-ids', instance_id,
@@ -830,6 +829,25 @@ def vmss_prototype_update(sub_args):
                 '--name', extension['name']
                 ], retries=3, check=False, retry_func=not_found_no_retry)
 
+    # Scale out 1 more VMSS instance to replace the previously deleted instance
+    # Note: this does not respect any changes that may have occured to the VMSS instance count during update
+    # from out-of-band node scaling tools such as cluster-autoscaler
+    output, _, _ = run(az(['vmss', 'show'], subscription) + [
+                       '--resource-group', resource_group,
+                       '--name', vmss
+                       ], retries=3)
+    vmss_info = json.loads(output)
+    capacity = vmss_info["sku"]["capacity"]
+    if isinstance(capacity, int):
+        # Increase the capacity of the VMSS by 1
+        run(az(['vmss', 'update'], subscription) + [
+            '--resource-group', resource_group,
+            '--name', vmss,
+            '--set',
+                'sku.capacity={}'.format(capacity + 1),
+            ], retries=3, check=False)
+    else:
+        logging.warning('Unable to determine capacity for VMSS {}, will not add back 1 instance'.format(vmss)
 
 def in_cluster(sub_args, func):
     '''

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -829,25 +829,26 @@ def vmss_prototype_update(sub_args):
                 '--name', extension['name']
                 ], retries=3, check=False, retry_func=not_found_no_retry)
 
-    # Scale out 1 more VMSS instance to replace the previously deleted instance
-    # Note: this does not respect any changes that may have occured to the VMSS instance count during update
-    # from out-of-band node scaling tools such as cluster-autoscaler
-    output, _, _ = run(az(['vmss', 'show'], subscription) + [
-                       '--resource-group', resource_group,
-                       '--name', vmss
-                       ], retries=3)
-    vmss_info = json.loads(output)
-    capacity = vmss_info["sku"]["capacity"]
-    if isinstance(capacity, int):
-        # Increase the capacity of the VMSS by 1
-        run(az(['vmss', 'update'], subscription) + [
-            '--resource-group', resource_group,
-            '--name', vmss,
-            '--set',
-                'sku.capacity={}'.format(capacity + 1),
-            ], retries=3, check=False)
-    else:
-        logging.warning('Unable to determine capacity for VMSS {}, will not add back 1 instance'.format(vmss)
+    if sub_args.new_updated_nodes > 0:
+        # Scale out 1 more VMSS instance to replace the previously deleted instance
+        # Note: this does not respect any changes that may have occured to the VMSS instance count during update
+        # from out-of-band node scaling tools such as cluster-autoscaler
+        output, _, _ = run(az(['vmss', 'show'], subscription) + [
+                        '--resource-group', resource_group,
+                        '--name', vmss
+                        ], retries=3)
+        vmss_info = json.loads(output)
+        capacity = lookup_one_value(vmss_info,'sku.capacity')
+        if capacity != None:
+            # Increase the capacity of the VMSS by the value of --new-updated-nodes
+            run(az(['vmss', 'update'], subscription) + [
+                '--resource-group', resource_group,
+                '--name', vmss,
+                '--set',
+                    'sku.capacity={0}'.format(capacity + sub_args.new_updated_nodes),
+                ], retries=3, check=False)
+        else:
+            logging.warning('Unable to determine capacity for VMSS {0}, will not add back 1 instance'.format(vmss))
 
 def in_cluster(sub_args, func):
     '''
@@ -952,6 +953,16 @@ def NodeName(v):
         raise argparse.ArgumentTypeError("Node name must be a vmss node:  eg k8s-pool-131414-vmss0003ax")
     return v
 
+def NewUpdatedNodes(v):
+    """
+    new-updated-nodes validation type for argparser
+    :param v: The proposed new-updated-nodes value
+    :return: The validated new-updated-nodes
+    """
+    if not isinstance(v, int):
+        raise argparse.ArgumentTypeError("new-updated-nodes must be an int:  eg 1")
+    return v
+
 
 def SubscriptionId(v):
     """
@@ -1016,6 +1027,8 @@ def register_commands(subparser):
                          description='Set up new/updated prototype')
     parser.add_argument('--target-node', required=True, type=NodeName,
                         help='Target node to use as the prototype source')
+    parser.add_argument('--new-updated-nodes', default=0, type=NewUpdatedNodes,
+                        help='Number of new nodes to add to the cluster after the VMSS has been updated from the prototype node (default: %(default)s)')
     parser.add_argument('--max-history', default=3, type=HistorySize,
                         help='Number of entries to keep in history - minimum is 2 - (default: %(default)s)')
     parser.add_argument('--grace-period', type=int, default=300,

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -838,10 +838,11 @@ def vmss_prototype_update(sub_args):
                         '--name', vmss
                         ], retries=3)
         vmss_info = json.loads(output)
-        capacity = lookup_one_value(vmss_info,'sku.capacity')
+        capacity = lookup_one_value(vmss_info, 'sku.capacity')
         if capacity != None:
             # Increase the capacity of the VMSS by the value of --new-updated-nodes
             run(az(['vmss', 'update'], subscription) + [
+                "--no-wait",
                 '--resource-group', resource_group,
                 '--name', vmss,
                 '--set',

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -960,8 +960,8 @@ def NewUpdatedNodes(v):
     :param v: The proposed new-updated-nodes value
     :return: The validated new-updated-nodes
     """
-    if not isinstance(v, int):
-        raise argparse.ArgumentTypeError("new-updated-nodes must be an int:  eg 1")
+    if not isinstance(v, int) or v < 0:
+        raise argparse.ArgumentTypeError("new-updated-nodes must be a positive int: eg 1")
     return v
 
 

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -842,11 +842,11 @@ def vmss_prototype_update(sub_args):
         if capacity != None:
             # Increase the capacity of the VMSS by the value of --new-updated-nodes
             run(az(['vmss', 'update'], subscription) + [
-                "--no-wait",
                 '--resource-group', resource_group,
                 '--name', vmss,
                 '--set',
                     'sku.capacity={0}'.format(capacity + sub_args.new_updated_nodes),
+                "--no-wait",
                 ], retries=3, check=False)
         else:
             logging.warning('Unable to determine capacity for VMSS {0}, will not add back 1 instance'.format(vmss))

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -846,7 +846,7 @@ def vmss_prototype_update(sub_args):
                 '--name', vmss,
                 '--set',
                     'sku.capacity={0}'.format(capacity + sub_args.new_updated_nodes),
-                "--no-wait",
+                "--no-wait"
                 ], retries=3, check=False)
         else:
             logging.warning('Unable to determine capacity for VMSS {0}, will not add back 1 instance'.format(vmss))


### PR DESCRIPTION
This PR modifies the `vmss-update` update behavior to delete the candidate node instance after a successful snapshot has been taken, and adds a new instance from the prototype-updated VMSS at the conclusion of the prototype update process.

This addresses the edge case in #26.

Arguably the current behavior is cleaner and more elegant, and so if we're able to figure out how to prevent #26 from happening we can restore the original functionality.