### PR TITLE
chore: rev helm chart to version 0.0.2

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Kamino vmss-prototype pattern image generator
 name: vmss-prototype
-version: 0.0.1
+version: 0.0.2
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com


### PR DESCRIPTION
This PR follows along from #27, rev'ing the version of the modified helm chart to version 0.0.2 to induce a new helm repo publication.