### PR TITLE
ci: discrete "release" and "push" github actions

### DIFF
--- a/.github/workflows/push-vmss-prototype.yml
+++ b/.github/workflows/push-vmss-prototype.yml
@@ -1,0 +1,30 @@
+name: Publish vmss-prototype image
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Identify image by this tag'
+        required: true
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: set env
+        run: echo "RELEASE_VERSION=${{github.event.inputs.image_tag}}-canary" >> $GITHUB_ENV
+        if: ${{github.event.inputs.image_tag != ''}}
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v1
+      - name: login to GitHub container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: vmss-prototype/Dockerfile
+          tags: |
+            ghcr.io/jackfrancis/kamino/vmss-prototype:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release-vmss-prototype.yml
+++ b/.github/workflows/release-vmss-prototype.yml
@@ -1,13 +1,8 @@
-name: release image
+name: Release vmss-prototype image
 on:
   push:
     tags:
       - 'image-v*' # push events for tags matching image-v for version (image-v1.0, etc)
-  workflow_dispatch:
-    inputs:
-      test_version:
-        description: 'Test image version to push'
-        required: true
 jobs:
   image:
     runs-on: ubuntu-latest
@@ -15,10 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: set env
         run: echo "RELEASE_VERSION=${GITHUB_REF:17}" >> $GITHUB_ENV # refs/tags/image-v1.0.0 substring starting at 1.0.0
-        if: ${{github.event.inputs.test_version == ''}}
-      - name: set env
-        run: echo "RELEASE_VERSION=${{github.event.inputs.test_version}}-canary" >> $GITHUB_ENV
-        if: ${{github.event.inputs.test_version != ''}}
       - name: setup buildx
         uses: docker/setup-buildx-action@v1
       - name: login to GitHub container registry


### PR DESCRIPTION
This PR adds a new "Publish vmss-prototype image", and renames the existing release CI job to "Release vmss-prototype image".

- The "Release vmss-prototype image" CI job is *only* engaged upon when a tag matching the `image*` pattern is added to the repository.
- The "Publish vmss-prototype image" CI job is *only* able to be manually engaged via the Github Actions UI.