### PR TITLE
chore: fix --new-updated-nodes args errata

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Kamino vmss-prototype pattern image generator
 name: vmss-prototype
-version: 0.0.2
+version: 0.0.3
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com

--- a/helm/vmss-prototype/templates/vmss-prototype.yaml
+++ b/helm/vmss-prototype/templates/vmss-prototype.yaml
@@ -65,7 +65,7 @@ spec:
             - update
             - --target-node
             - {{ .Values.kamino.targetNode | quote }}
-            -- new-updated-nodes
+            - --new-updated-nodes
             - {{ .Values.kamino.newUpdatedNodes | quote }}
             - --grace-period
             - {{ required "missing required kamino.drain.gracePeriod" .Values.kamino.drain.gracePeriod | quote }}

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -960,7 +960,11 @@ def NewUpdatedNodes(v):
     :param v: The proposed new-updated-nodes value
     :return: The validated new-updated-nodes
     """
-    if not isinstance(v, int) or v < 0:
+    if isinstance(v, string):
+        if not v.isdigit():
+            raise argparse.ArgumentTypeError("new-updated-nodes must be a positive int: eg 1")
+    v = int(v)
+    if v < 0:
         raise argparse.ArgumentTypeError("new-updated-nodes must be a positive int: eg 1")
     return v
 

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -960,7 +960,7 @@ def NewUpdatedNodes(v):
     :param v: The proposed new-updated-nodes value
     :return: The validated new-updated-nodes
     """
-    if isinstance(v, string):
+    if isinstance(v, str):
         if not v.isdigit():
             raise argparse.ArgumentTypeError("new-updated-nodes must be a positive int: eg 1")
     v = int(v)


### PR DESCRIPTION
This PR fixes some bugs in the implementation of the new feature `--new-updated-nodes`. Obviously the lack of automated testing makes these changes more painful to integrate. :/