### PR TITLE
ci: generate proper version tag during vmss-prototype-image release job

### DIFF
--- a/.github/workflows/release-vmss-prototype-image.yml
+++ b/.github/workflows/release-vmss-prototype-image.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF:17}" >> $GITHUB_ENV # refs/tags/image-v1.0.0 substring starting at 1.0.0
+        run: echo "RELEASE_VERSION=${GITHUB_REF:31}" >> $GITHUB_ENV # refs/tags/vmss-prototype-image-v1.0.0 substring starting at v1.0.0
       - name: setup buildx
         uses: docker/setup-buildx-action@v1
       - name: login to GitHub container registry


### PR DESCRIPTION
This PR fixes the number of prepending chars to throw out with the newer, longer "vmss-prototype-image" tag prefix string.