### PR TITLE
fix: don't uncordon and enable cluster-autoscaler after node is deleted

### DIFF
--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -730,13 +730,13 @@ def vmss_prototype_update(sub_args):
 
                 # Delete the instance to prevent idns side-effects from future VMs coming online based on its prototype
                 # See https://github.com/jackfrancis/kamino/issues/26
-                ret = run(az(['vmss', 'delete-instances'], subscription) + [
+                stdout, stderr, exit_code = run(az(['vmss', 'delete-instances'], subscription) + [
                     '--resource-group', resource_group,
                     '--name', vmss,
                     '--instance-ids', instance_id,
                     '--no-wait'
                     ], retries=3, check=False, retry_func=not_found_no_retry)
-                if ret == 0:
+                if exit_code == 0:
                     nodeDeleted = True
 
             finally:

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -674,6 +674,7 @@ def vmss_prototype_update(sub_args):
                  '--overwrite'
                  ], retries=3, retry_func=not_found_no_retry)
 
+            nodeDeleted = False
             try:
                 # Gracefully stop workloads on this VM.
                 run(['kubectl', 'cordon',
@@ -735,6 +736,22 @@ def vmss_prototype_update(sub_args):
                     '--instance-ids', instance_id,
                     '--no-wait'
                     ], retries=3, check=False, retry_func=not_found_no_retry)
+                nodeDeleted = True
+
+            finally:
+                if not nodeDeleted:
+                    # Let it be a productive member of the cluster again
+                    # We ignore errors here since the VM may no longer exist
+                    # We best-effort uncordon it.
+                    run(['kubectl', 'uncordon',
+                        target_node
+                        ], retries=3, check=False, retry_func=not_found_no_retry)
+
+                    # Allow the cluster from scaling away the node...
+                    run(['kubectl', 'annotate', 'node',
+                        target_node,
+                        'cluster-autoscaler.kubernetes.io/scale-down-disabled-'
+                        ], retries=3, check=False, retry_func=not_found_no_retry)
 
         # Build the image version from the snapshow we have
         output = vmss_build_sig_image(subscription, resource_group, sig_name, image_definition, version, snapshot)

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -736,20 +736,6 @@ def vmss_prototype_update(sub_args):
                     '--no-wait'
                     ], retries=3, check=False, retry_func=not_found_no_retry)
 
-            finally:
-                # Let it be a productive member of the cluster again
-                # We ignore errors here since the VM may no longer exist
-                # We best-effort uncordon it.
-                run(['kubectl', 'uncordon',
-                     target_node
-                     ], retries=3, check=False, retry_func=not_found_no_retry)
-
-                # Allow the cluster from scaling away the node...
-                run(['kubectl', 'annotate', 'node',
-                     target_node,
-                     'cluster-autoscaler.kubernetes.io/scale-down-disabled-'
-                     ], retries=3, check=False, retry_func=not_found_no_retry)
-
         # Build the image version from the snapshow we have
         output = vmss_build_sig_image(subscription, resource_group, sig_name, image_definition, version, snapshot)
         image_version = json.loads(output)

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -730,13 +730,14 @@ def vmss_prototype_update(sub_args):
 
                 # Delete the instance to prevent idns side-effects from future VMs coming online based on its prototype
                 # See https://github.com/jackfrancis/kamino/issues/26
-                run(az(['vmss', 'delete-instances'], subscription) + [
+                ret = run(az(['vmss', 'delete-instances'], subscription) + [
                     '--resource-group', resource_group,
                     '--name', vmss,
                     '--instance-ids', instance_id,
                     '--no-wait'
                     ], retries=3, check=False, retry_func=not_found_no_retry)
-                nodeDeleted = True
+                if ret == 0:
+                    nodeDeleted = True
 
             finally:
                 if not nodeDeleted:


### PR DESCRIPTION
This PR finishes the work to delete the instance after taking the snapshot. We forgot to delete the part where we re-enable the node (which we don't want to do, because the underlying VMSS instance is in a state of deletion!)