### PR TITLE
Updated helm chart for use with v0.0.5 of vmss-prototype

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Kamino vmss-prototype pattern image generator
 name: vmss-prototype
-version: 0.0.4
+version: 0.0.5
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com

--- a/helm/vmss-prototype/templates/vmss-prototype.yaml
+++ b/helm/vmss-prototype/templates/vmss-prototype.yaml
@@ -93,6 +93,11 @@ spec:
             - {{ .Values.kamino.auto.minimumReadyTime | quote }}
             - --minimum-candidates
             - {{ .Values.kamino.auto.minimumCandidates | quote }}
+            - --maximum-image-age
+            - {{ .Values.kamino.auto.maximumImageAge | quote }}
+            {{- if .Values.kamino.auto.dryRun }}
+            - --dry-run
+            {{- end }}
             {{- else }}
             # Just a status run
             - status

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -8,9 +8,9 @@ kamino:
     # TODO:  Point these to our public container registry once we have it setup
     imageRegistry: ghcr.io
     imageRepository: jackfrancis/kamino/vmss-prototype
-    imageTag: v0.0.3
+    imageTag: v0.0.5
     # Pulling by hash has stronger assurance that the container is unchanged
-    imageHash: "a421ff768a798d581178626386c67117af2e2262dde334cef15d8f92df1a178f"
+    imageHash: "d154002ee4db8ca691357b7cc7ceb864d3e00f67a8a1be5554d749469d609c3f"
     pullByHash: true
 
     # include the name of the image pull secret in your cluster if you
@@ -51,6 +51,18 @@ kamino:
     # in ready state before you commit to picking one of them as a good
     # candidate.
     minimumCandidates: 1
+
+    # The maximum age of the current VMSS Prototype image before the auto
+    # node selection logic will try to find a new candate even if there
+    # has been no OS update/patch.  If set to 0, this no age is defined
+    # and thus the age is never considered.  Otherwise it is the number
+    # of days in age of the current image.  For example, if set to 7 days,
+    # once the current VMSS Prototype image is over 7 days old, the auto
+    # node selection process will not limit its node selection only to nodes
+    # that have an OS update/patch that is newer than the prior image.
+    # OS Updates/patches are always preferred but if the age is over the
+    # limit, an OS update/patch is not required.
+    maximumImageAge: 0
 
     # The annotation on a node that holds the last time a patch was
     # "applied"

--- a/vmss-prototype/smoketest3.sh
+++ b/vmss-prototype/smoketest3.sh
@@ -33,7 +33,9 @@ ${HELM3} upgrade --install ${DEPLOYMENT_NAME} ../helm/vmss-prototype \
     --set kamino.drain.force=true \
     --set kamino.targetVMSS=ALL \
     --set kamino.auto.lastPatchAnnotation=LatestOSPatch \
-    --set kamino.auto.pendingRebootAnnotation=PendingReboot
+    --set kamino.auto.pendingRebootAnnotation=PendingReboot \
+    --set kamino.auto.maximumImageAge=15 \
+    --set kamino.auto.dryRun=true
 
 kubectl get jobs --namespace ${NAMESPACE} --selector app=kamino-vmss-prototype
 


### PR DESCRIPTION
This adds the minimum image age feature to the helm chart such
that the container version 0.0.4+ will use it.  Note that this
means that this helm chart must be used with 0.0.4 or later
containers due to providing that extra command line option.

This also fixes the "dryRun" setting in the helm chart to actually
be wired to the --dry-run option of the container.  (I had forgotten
to complete that last time)

Updated smoketest3.sh to be dry-run and set an image age