### PR TITLE
Trivial fix of reporting the failed to drain of a node.

### DIFF
--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -703,7 +703,7 @@ def vmss_prototype_update(sub_args):
 
                 if rc != 0:
                     if not sub_args.force:
-                        fatal_error('Could not drain node {0}', target_node)
+                        fatal_error('Could not drain node {0}'.format(target_node))
 
                     # Move any none-daemonset (or node) pods off of this node that have not
                     # drained (they should have drained already but just in case)


### PR DESCRIPTION
When a drain fails, the error message rendering had an error in
it and then crashed trying to render the error message.

Fixes #49 