### PR TITLE
kamino CI via aks-engine E2E tests

### DIFF
--- a/.github/workflows/push-vmss-prototype-image.yml
+++ b/.github/workflows/push-vmss-prototype-image.yml
@@ -44,6 +44,10 @@ jobs:
           echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
           sudo apt-get update
           sudo apt-get install helm
+      - name: install k
+        run: |
+          sudo curl -o /usr/local/bin/k https://raw.githubusercontent.com/jakepearson/k/master/k
+          sudo chmod +x /usr/local/bin/k
       - name: checkout aks-engine
         uses: actions/checkout@v2
         with:
@@ -64,7 +68,7 @@ jobs:
           TENANT_ID: ${{ secrets.TEST_AZURE_TENANT_ID }}
           USE_MANAGED_IDENTITY: false
           SKIP_LOGS_COLLECTION: true
-          CLEANUP_ON_EXIT: false
+          CLEANUP_ON_EXIT: true
           CLEANUP_IF_FAIL: false
           GINKGO_FOCUS: "should be able to install vmss node prototype"
           RUN_VMSS_NODE_PROTOTYPE: true

--- a/.github/workflows/push-vmss-prototype-image.yml
+++ b/.github/workflows/push-vmss-prototype-image.yml
@@ -50,6 +50,9 @@ jobs:
           repository: Azure/aks-engine
           path: aks-engine
           ref: master # TODO change to a strongly-versioned ref once the kamino E2E integrations are in a released version
+      - name: build aks-engine binary
+        run: make build-binary
+        working-directory: aks-engine
       - name: run aks-engine E2E
         env:
           ORCHESTRATOR_RELEASE: "1.19"
@@ -65,6 +68,5 @@ jobs:
           GINKGO_FOCUS: "should be able to install vmss node prototype"
           RUN_VMSS_NODE_PROTOTYPE: true
           KAMINO_VMSS_PROTOTYPE_IMAGE_TAG: ${{ env.RELEASE_VERSION }}
-        run: |
-          make test-kubernetes
+        run: make test-kubernetes
         working-directory: aks-engine

--- a/.github/workflows/push-vmss-prototype-image.yml
+++ b/.github/workflows/push-vmss-prototype-image.yml
@@ -62,6 +62,7 @@ jobs:
           CLIENT_SECRET: ${{ secrets.TEST_AZURE_SP_PW }}
           LOCATION: "westus2"
           TENANT_ID: ${{ secrets.TEST_AZURE_TENANT_ID }}
+          USE_MANAGED_IDENTITY: false
           SKIP_LOGS_COLLECTION: true
           CLEANUP_ON_EXIT: false
           CLEANUP_IF_FAIL: false

--- a/.github/workflows/push-vmss-prototype-image.yml
+++ b/.github/workflows/push-vmss-prototype-image.yml
@@ -19,9 +19,12 @@ jobs:
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - name: set env
+      - name: assign tag based on manual input
         run: echo "RELEASE_VERSION=${{github.event.inputs.image_tag}}-canary" >> $GITHUB_ENV
         if: ${{github.event.inputs.image_tag != ''}}
+      - name: assign tag automatically based on current commit sha
+        run: echo "RELEASE_VERSION=$(git rev-parse --short "$GITHUB_SHA")-canary" >> $GITHUB_ENV
+        if: ${{github.event.inputs.image_tag == ''}}
       - name: setup buildx
         uses: docker/setup-buildx-action@v1
       - name: login to GitHub container registry

--- a/.github/workflows/push-vmss-prototype-image.yml
+++ b/.github/workflows/push-vmss-prototype-image.yml
@@ -5,6 +5,12 @@ on:
       image_tag:
         description: 'Identify image by this tag'
         required: true
+  pull_request:
+    paths:
+      - vmss-prototype/vmss-prototype
+      - Dockerfile
+    branches:
+      - main
 jobs:
   image:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-vmss-prototype-image.yml
+++ b/.github/workflows/push-vmss-prototype-image.yml
@@ -7,9 +7,13 @@ on:
         required: true
 jobs:
   image:
+    environment: kamino-ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: set env
         run: echo "RELEASE_VERSION=${{github.event.inputs.image_tag}}-canary" >> $GITHUB_ENV
         if: ${{github.event.inputs.image_tag != ''}}
@@ -28,3 +32,41 @@ jobs:
           file: vmss-prototype/Dockerfile
           tags: |
             ghcr.io/jackfrancis/kamino/vmss-prototype:${{ env.RELEASE_VERSION }}
+      - name: install go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
+      - name: install ginkgo
+        run: go get -u github.com/onsi/ginkgo/ginkgo
+      - name: install helm
+        run: |
+          curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+          sudo apt-get install apt-transport-https --yes
+          echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+          sudo apt-get update
+          sudo apt-get install helm
+      - name: checkout aks-engine
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/aks-engine
+          path: aks-engine
+          ref: master # TODO change to a strongly-versioned ref once the kamino E2E integrations are in a released version
+      - name: run aks-engine E2E
+        env:
+          ORCHESTRATOR_RELEASE: "1.19"
+          CLUSTER_DEFINITION: "examples/kubernetes.json"
+          SUBSCRIPTION_ID: ${{ secrets.TEST_AZURE_SUB_ID }}
+          CLIENT_ID: ${{ secrets.TEST_AZURE_SP_ID }}
+          CLIENT_SECRET: ${{ secrets.TEST_AZURE_SP_PW }}
+          CLIENT_OBJECTID: ${{ secrets.TEST_AZURE_SP_OID }}
+          LOCATION: "westus2"
+          TENANT_ID: ${{ secrets.TEST_AZURE_TENANT_ID }}
+          SKIP_LOGS_COLLECTION: true
+          CLEANUP_ON_EXIT: false
+          CLEANUP_IF_FAIL: false
+          GINKGO_FOCUS: "should be able to install vmss node prototype"
+          RUN_VMSS_NODE_PROTOTYPE: true
+          KAMINO_VMSS_PROTOTYPE_IMAGE_TAG: ${{ env.RELEASE_VERSION }}
+        run: |
+          make test-kubernetes
+        working-directory: aks-engine

--- a/.github/workflows/push-vmss-prototype-image.yml
+++ b/.github/workflows/push-vmss-prototype-image.yml
@@ -66,7 +66,6 @@ jobs:
           CLIENT_SECRET: ${{ secrets.TEST_AZURE_SP_PW }}
           LOCATION: "westus2"
           TENANT_ID: ${{ secrets.TEST_AZURE_TENANT_ID }}
-          USE_MANAGED_IDENTITY: false
           SKIP_LOGS_COLLECTION: true
           CLEANUP_ON_EXIT: true
           CLEANUP_IF_FAIL: false

--- a/.github/workflows/push-vmss-prototype-image.yml
+++ b/.github/workflows/push-vmss-prototype-image.yml
@@ -57,7 +57,6 @@ jobs:
           SUBSCRIPTION_ID: ${{ secrets.TEST_AZURE_SUB_ID }}
           CLIENT_ID: ${{ secrets.TEST_AZURE_SP_ID }}
           CLIENT_SECRET: ${{ secrets.TEST_AZURE_SP_PW }}
-          CLIENT_OBJECTID: ${{ secrets.TEST_AZURE_SP_OID }}
           LOCATION: "westus2"
           TENANT_ID: ${{ secrets.TEST_AZURE_TENANT_ID }}
           SKIP_LOGS_COLLECTION: true

--- a/.github/workflows/push-vmss-prototype-image.yml
+++ b/.github/workflows/push-vmss-prototype-image.yml
@@ -7,7 +7,6 @@ on:
         required: true
 jobs:
   image:
-    environment: kamino-ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR defines a GitHub Action job to automatically run aks-engine E2E tests against the vmss-prototype changes being delivered in a PR.