### PR TITLE
ci: correct Dockerfile path

### DIFF
--- a/.github/workflows/push-vmss-prototype-image.yml
+++ b/.github/workflows/push-vmss-prototype-image.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - vmss-prototype/vmss-prototype
-      - Dockerfile
+      - vmss-prototype/Dockerfile
     branches:
       - main
 jobs:


### PR DESCRIPTION
This PR corrects the relative `Dockerfile` filepath for engaging the GitHub Actions CI to build a new vmss-prototype image.