### PR TITLE
ci: update GitHub Actions definitions

### DIFF
--- a/.github/workflows/build-and-test-vmss-prototype-image.yml
+++ b/.github/workflows/build-and-test-vmss-prototype-image.yml
@@ -1,0 +1,85 @@
+name: Build and test vmss-prototype image
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Identify image by this tag'
+        required: true
+  pull_request:
+    paths:
+      - vmss-prototype/vmss-prototype
+      - vmss-prototype/Dockerfile
+    branches:
+      - main
+jobs:
+  build-and-test-vmss-prototype:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: assign tag based on manual input
+        run: echo "RELEASE_VERSION=${{github.event.inputs.image_tag}}-canary" >> $GITHUB_ENV
+        if: ${{github.event.inputs.image_tag != ''}}
+      - name: assign tag automatically based on current commit sha
+        run: echo "RELEASE_VERSION=$(git rev-parse --short "$GITHUB_SHA")-canary" >> $GITHUB_ENV
+        if: ${{github.event.inputs.image_tag == ''}}
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v1
+      - name: login to GitHub container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: vmss-prototype/Dockerfile
+          tags: |
+            ghcr.io/jackfrancis/kamino/vmss-prototype:${{ env.RELEASE_VERSION }}
+      - name: install go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15'
+      - name: install ginkgo
+        run: go get -u github.com/onsi/ginkgo/ginkgo
+      - name: install helm
+        run: |
+          curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+          sudo apt-get install apt-transport-https --yes
+          echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+          sudo apt-get update
+          sudo apt-get install helm
+      - name: install k
+        run: |
+          sudo curl -o /usr/local/bin/k https://raw.githubusercontent.com/jakepearson/k/master/k
+          sudo chmod +x /usr/local/bin/k
+      - name: checkout aks-engine
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/aks-engine
+          path: aks-engine
+          ref: master # TODO change to a strongly-versioned ref once the kamino E2E integrations are in a released version
+      - name: build aks-engine binary
+        run: make build-binary
+        working-directory: aks-engine
+      - name: run aks-engine E2E
+        env:
+          ORCHESTRATOR_RELEASE: "1.19"
+          CLUSTER_DEFINITION: "examples/kubernetes.json"
+          SUBSCRIPTION_ID: ${{ secrets.TEST_AZURE_SUB_ID }}
+          CLIENT_ID: ${{ secrets.TEST_AZURE_SP_ID }}
+          CLIENT_SECRET: ${{ secrets.TEST_AZURE_SP_PW }}
+          LOCATION: "westus2"
+          TENANT_ID: ${{ secrets.TEST_AZURE_TENANT_ID }}
+          SKIP_LOGS_COLLECTION: true
+          CLEANUP_ON_EXIT: true
+          CLEANUP_IF_FAIL: false
+          GINKGO_FOCUS: "should be able to install vmss node prototype"
+          RUN_VMSS_NODE_PROTOTYPE: true
+          KAMINO_VMSS_PROTOTYPE_IMAGE_TAG: ${{ env.RELEASE_VERSION }}
+        run: make test-kubernetes
+        working-directory: aks-engine

--- a/.github/workflows/publish-helm-repo.yml
+++ b/.github/workflows/publish-helm-repo.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - helm/vmss-prototype/Chart.yaml
+      - helm/vmss-prototype/values.yaml
+      - helm/vmss-prototype/.helmignore
+      - helm/vmss-prototype/templates/**
 
 jobs:
   release:

--- a/.github/workflows/test-vmss-prototype-helm-chart.yml
+++ b/.github/workflows/test-vmss-prototype-helm-chart.yml
@@ -1,30 +1,23 @@
-name: Publish vmss-prototype image
+name: Test vmss-prototype Helm Chart
 on:
-  workflow_dispatch:
-    inputs:
-      image_tag:
-        description: 'Identify image by this tag'
-        required: true
   pull_request:
     paths:
-      - vmss-prototype/vmss-prototype
-      - vmss-prototype/Dockerfile
+      - helm/vmss-prototype/Chart.yaml
+      - helm/vmss-prototype/values.yaml
+      - helm/vmss-prototype/.helmignore
+      - helm/vmss-prototype/templates/**
     branches:
       - main
 jobs:
-  image:
+  test-vmss-prototype-helm-chart:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - name: assign tag based on manual input
-        run: echo "RELEASE_VERSION=${{github.event.inputs.image_tag}}-canary" >> $GITHUB_ENV
-        if: ${{github.event.inputs.image_tag != ''}}
       - name: assign tag automatically based on current commit sha
         run: echo "RELEASE_VERSION=$(git rev-parse --short "$GITHUB_SHA")-canary" >> $GITHUB_ENV
-        if: ${{github.event.inputs.image_tag == ''}}
       - name: setup buildx
         uses: docker/setup-buildx-action@v1
       - name: login to GitHub container registry
@@ -80,6 +73,6 @@ jobs:
           CLEANUP_IF_FAIL: false
           GINKGO_FOCUS: "should be able to install vmss node prototype"
           RUN_VMSS_NODE_PROTOTYPE: true
-          KAMINO_VMSS_PROTOTYPE_IMAGE_TAG: ${{ env.RELEASE_VERSION }}
+          KAMINO_VMSS_PROTOTYPE_LOCAL_CHART_PATH: ${{ github.workspace }}/helm/vmss-prototype
         run: make test-kubernetes
         working-directory: aks-engine


### PR DESCRIPTION
This PR makes 3 changes:

- Changes the name of the "build and test vmss-prototype image" action job to `build-and-test-vmss-prototype`
- Only publish helm chart upon merge to main if the relevant chart files have been updated
- Add a new `test-vmss-prototype-helm-chart` action job to run on PRs that deliver changes to the helm chart