### PR TITLE
ci: enable dry_run option for helm chart test

### DIFF
--- a/.github/workflows/test-vmss-prototype-helm-chart.yml
+++ b/.github/workflows/test-vmss-prototype-helm-chart.yml
@@ -1,5 +1,11 @@
 name: Test vmss-prototype Helm Chart
 on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Perform dry run?'
+        required: true
+        default: 'true'
   pull_request:
     paths:
       - helm/vmss-prototype/Chart.yaml
@@ -18,6 +24,12 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: assign tag automatically based on current commit sha
         run: echo "RELEASE_VERSION=$(git rev-parse --short "$GITHUB_SHA")-canary" >> $GITHUB_ENV
+      - name: assign dry run config on manual input
+        run: echo "DRY_RUN=${{github.event.inputs.dry_run}}" >> $GITHUB_ENV
+        if: ${{github.event.inputs.dry_run != ''}}
+      - name: default dry run config to 'true' if not a manual run
+        run: echo "DRY_RUN=true" >> $GITHUB_ENV
+        if: ${{github.event.inputs.dry_run == ''}}
       - name: setup buildx
         uses: docker/setup-buildx-action@v1
       - name: login to GitHub container registry
@@ -74,5 +86,6 @@ jobs:
           GINKGO_FOCUS: "should be able to install vmss node prototype"
           RUN_VMSS_NODE_PROTOTYPE: true
           KAMINO_VMSS_PROTOTYPE_LOCAL_CHART_PATH: ${{ github.workspace }}/helm/vmss-prototype
+          KAMINO_VMSS_PROTOTYPE_DRY_RUN: ${{ env.DRY_RUN }}
         run: make test-kubernetes
         working-directory: aks-engine


### PR DESCRIPTION
This PR enables the dry run option when running aks-engine E2E tests to test helm chart changes.