### PR TITLE
fix: missing node name in log message

### DIFF
--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -965,7 +965,7 @@ def get_candidate_nodes(vmss, nodes, node_ignore_names, node_ignore_annotations,
                     ready_time = int(mktime_from_kubernetes(condition['lastHeartbeatTime']) - mktime_from_kubernetes(condition['lastTransitionTime']))
                 break
         if not ready_time:
-            logging.debug('IGNORED: Node {0} is not ready')
+            logging.debug('IGNORED: Node {0} is not ready'.format(node_name))
             continue
 
         if ready_time < minimum_ready_time:


### PR DESCRIPTION
This PR fixes a missing node name variable string substition reference in a vmss-prototype runtime log message.