### PR TITLE
release: vmss-prototype chart 0.0.6

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Kamino vmss-prototype pattern image generator
 name: vmss-prototype
-version: 0.0.5
+version: 0.0.6
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -8,7 +8,7 @@ kamino:
     # TODO:  Point these to our public container registry once we have it setup
     imageRegistry: ghcr.io
     imageRepository: jackfrancis/kamino/vmss-prototype
-    imageTag: v0.0.5
+    imageTag: v0.0.6
     # Pulling by hash has stronger assurance that the container is unchanged
     imageHash: "d154002ee4db8ca691357b7cc7ceb864d3e00f67a8a1be5554d749469d609c3f"
     pullByHash: true


### PR DESCRIPTION
This PR updates the official vmss-prototype chart to refer to the v0.0.6 version of vmss-prototype, and revs the chart version to 0.0.6.