### PR TITLE
Add kamino.auto.crontab feature

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Kamino vmss-prototype pattern image generator
 name: vmss-prototype
-version: 0.0.6
+version: 0.0.7
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com

--- a/helm/vmss-prototype/README.md
+++ b/helm/vmss-prototype/README.md
@@ -206,7 +206,8 @@ Kamino can follow some rules for automatic node selection.  These are the parame
   - When set to true, will run auto-update job on a periodic basis.  This requires that you use the `kamino.targetVMSS` setting since cronjobs only make sense in automatic mode.
   - This is how we recommend running Kamino
 
-- `kaminog.auto.cronjob.schedule` (optional - defaults to "`42 0 * * *`")
+- `kamino.auto.cronjob.schedule` (optional - defaults to "`42 0 * * *`")
+
   - This value only has meaning if cronjob is enabled
   - Format of this value is [based on UNIX cron syntax](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax)
     - Our default value is "Daily, 42 minutes after midnight"

--- a/helm/vmss-prototype/README.md
+++ b/helm/vmss-prototype/README.md
@@ -209,6 +209,8 @@ Kamino can follow some rules for automatic node selection.  These are the parame
 - `kaminog.auto.cronjob.schedule` (optional - defaults to "`42 0 * * *`")
   - This value only has meaning if cronjob is enabled
   - Format of this value is [based on UNIX cron syntax](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax)
+    - Our default value is "Daily, 42 minutes after midnight"
+    - You can use web tools like [crontab.guru](https://crontab.guru/) to help generate crontab schedule expressions
   - Running this daily will result in only updating the image when there is a suitable candidate to become the new image.
     - This is how you can have all of this running "lights out"
 

--- a/helm/vmss-prototype/README.md
+++ b/helm/vmss-prototype/README.md
@@ -207,7 +207,6 @@ Kamino can follow some rules for automatic node selection.  These are the parame
   - This is how we recommend running Kamino
 
 - `kamino.auto.cronjob.schedule` (optional - defaults to "`42 0 * * *`")
-
   - This value only has meaning if cronjob is enabled
   - Format of this value is [based on UNIX cron syntax](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax)
     - Our default value is "Daily, 42 minutes after midnight"

--- a/helm/vmss-prototype/README.md
+++ b/helm/vmss-prototype/README.md
@@ -202,6 +202,16 @@ Kamino can follow some rules for automatic node selection.  These are the parame
 - `kamino.auto.dryRun` (optional - defaults to false)
   - If set to true, the auto-update process will only show what choices it made but not actually execute the update process.
 
+- `kamino.auto.cronjob.enabled` (optional - defaults to false)
+  - When set to true, will run auto-update job on a periodic basis.  This requires that you use the `kamino.targetVMSS` setting since cronjobs only make sense in automatic mode.
+  - This is how we recommend running Kamino
+
+- `kaminog.auto.cronjob.schedule` (optional - defaults to "`42 0 * * *`")
+  - This value only has meaning if cronjob is enabled
+  - Format of this value is [based on UNIX cron syntax](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax)
+  - Running this daily will result in only updating the image when there is a suitable candidate to become the new image.
+    - This is how you can have all of this running "lights out"
+
 ### Manual node selection
 
 When running lower level, you can manually select the node that will be used as the prototype.  Internally, this is what the automatic node selection runs after selecting the node.

--- a/helm/vmss-prototype/README.md
+++ b/helm/vmss-prototype/README.md
@@ -169,6 +169,8 @@ The following Helm Chart values are exposed to configure a `vmss-prototype` rele
 
 Kamino can follow some rules for automatic node selection.  These are the parameters for the helm chart (in addition to the above) to enable this.
 
+The automatic mode can also be enabled as a cronjob (periodic job) that will look to apply the automated processes without manual deployment each time.  This process can then be a fully lights-out operation of Kamino as it automatically detects when a new prototype image is needed (based on parameters provided) and produces it.
+
 - `kamino.targetVMSS` (required to run in automatic mode)
   - A value of `ALL` will automatically scan for all VMSS pools
     - e.g., `--set kamino.targetVMSS=ALL`

--- a/helm/vmss-prototype/templates/vmss-prototype.yaml
+++ b/helm/vmss-prototype/templates/vmss-prototype.yaml
@@ -1,9 +1,33 @@
 {{- if hasKey .Values "kamino" -}}
+
+# Pick our job name here
 {{- $jobName := printf "%s-%s" .Values.kamino.name "status" -}}
+{{- if hasKey .Values.kamino "targetVMSS" -}}
+{{- $jobName = printf "%s-%s" .Values.kamino.name "autoupdate" -}}
+{{- else -}}
 {{- if hasKey .Values.kamino "targetNode" -}}
 {{- $jobName = printf "%s-%s" .Values.kamino.name (substr 0 (int (sub (len .Values.kamino.targetNode) 6)) .Values.kamino.targetNode) -}}
 {{- end -}}
+{{- end -}}
 
+# If cronjob is enabled and we must have a targetVMSS...
+{{- if .Values.kamino.auto.cronjob.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ $jobName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.kamino.labels.app }}
+    kamino: {{ $jobName }}
+    helm/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    targetVMSS: {{ required "Kamino cronjob requires setting targetVMSS" .Values.kamino.targetVMSS }}
+spec:
+  schedule: {{ .Values.kamino.auto.cronjob.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+{{- else }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -13,159 +37,176 @@ metadata:
     app: {{ .Values.kamino.labels.app }}
     kamino: {{ $jobName }}
     helm/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    {{- if hasKey .Values.kamino "targetVMSS" }}
+    targetVMSS: {{ .Values.kamino.targetVMSS }}
+    {{- else }}
     {{- if hasKey .Values.kamino "targetNode" }}
     targetNode: {{ .Values.kamino.targetNode }}
     {{- end }}
+    {{- end }}
 spec:
-  template:
-    metadata:
-      labels:
-        app: {{ .Values.kamino.labels.app }}
-        kamino: {{ $jobName }}
-        helm/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-        {{- if hasKey .Values.kamino "targetNode" }}
-        targetNode: {{ .Values.kamino.targetNode }}
-        {{- end }}
-    spec:
-      restartPolicy: Never
+{{- end }}
 
-      {{- if hasKey .Values.kamino.container "pullSecret" }}
-      imagePullSecrets:
-        - name: {{ .Values.kamino.container.pullSecret }}
-      {{- end}}
-
-      # We set up a required affinity run on a node that is
-      # note the target node we are about to shut down.
-      # (Only if we have a targetNode)
-      {{- if hasKey .Values.kamino "targetNode" }}
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchFields:
-              - key: metadata.name
-                operator: NotIn
-                values:
-                - {{ .Values.kamino.targetNode }}
-      {{- end }}
-
-      containers:
-        - name: {{ .Values.kamino.name }}
-          image: {{ template "image.full" .Values.kamino.container }}
-          imagePullPolicy: {{ template "image.pull" .Values.kamino.container }}
-
-          command:
-            - vmss-prototype
-          args:
-            - --in-cluster
-            - --log-level
-            - {{ required "missing required kamino.logLevel" .Values.kamino.logLevel }}
-            {{- if hasKey .Values.kamino "targetNode" }}
-            # Use the target node as our source for the new prototype image
-            - update
-            - --target-node
-            - {{ .Values.kamino.targetNode | quote }}
-            - --new-updated-nodes
-            - {{ .Values.kamino.newUpdatedNodes | quote }}
-            - --grace-period
-            - {{ required "missing required kamino.drain.gracePeriod" .Values.kamino.drain.gracePeriod | quote }}
-            - --max-history
-            - {{ required "missing required kamino.imageHistory" .Values.kamino.imageHistory | quote }}
-            {{- else if hasKey .Values.kamino "targetVMSS" }}
-            - --log-prefix
-            - auto-update
-            - auto-update
-            - --new-updated-nodes
-            - {{ .Values.kamino.newUpdatedNodes | quote }}
-            - --grace-period
-            - {{ required "missing required kamino.drain.gracePeriod" .Values.kamino.drain.gracePeriod | quote }}
-            - --max-history
-            - {{ required "missing required kamino.imageHistory" .Values.kamino.imageHistory | quote }}
-            {{- if not (eq .Values.kamino.targetVMSS "ALL") }}
-            - --target-vmss
-            - {{ .Values.kamino.targetVMSS | quote }}
-            {{- end }}
-            - --last-patch-annotation
-            - {{ required "missing requires kamino.auto.lastPatchAnnotation" .Values.kamino.auto.lastPatchAnnotation | quote }}
-            - --pending-reboot-annotation
-            - {{ required "missing requires kamino.auto.pendingRebootAnnotation" .Values.kamino.auto.pendingRebootAnnotation | quote }}
-            - --minimum-ready-time
-            - {{ .Values.kamino.auto.minimumReadyTime | quote }}
-            - --minimum-candidates
-            - {{ .Values.kamino.auto.minimumCandidates | quote }}
-            - --maximum-image-age
-            - {{ .Values.kamino.auto.maximumImageAge | quote }}
-            {{- if .Values.kamino.auto.dryRun }}
-            - --dry-run
-            {{- end }}
+# This is indented like it is under either the Job.spec or CronJob.spec.jobTemplate.spec
+      template:
+        metadata:
+          labels:
+            app: {{ .Values.kamino.labels.app }}
+            kamino: {{ $jobName }}
+            helm/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+            {{- if hasKey .Values.kamino "targetVMSS" }}
+            targetVMSS: {{ .Values.kamino.targetVMSS }}
             {{- else }}
-            # Just a status run
-            - status
+            {{- if hasKey .Values.kamino "targetNode" }}
+            targetNode: {{ .Values.kamino.targetNode }}
             {{- end }}
+            {{- end }}
+        spec:
+          restartPolicy: Never
 
-          env:
-            # We use the in-cluster kubeconfig
-            - name: KUBECONFIG
-              value: /.kubeconfig
+          {{- if hasKey .Values.kamino.container "pullSecret" }}
+          imagePullSecrets:
+            - name: {{ .Values.kamino.container.pullSecret }}
+          {{- end}}
 
-            # This gets mapped here since the node has cloud local CA bundles we need
-            - name: REQUESTS_CA_BUNDLE
-              value: /etc/ssl/certs/ca-certificates.crt
+          # We set up a required affinity to run on a node that is
+          # not the target node we are about to shut down.
+          # (Only if we have a targetNode)
+          {{- if hasKey .Values.kamino "targetNode" }}
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchFields:
+                  - key: metadata.name
+                    operator: NotIn
+                    values:
+                    - {{ .Values.kamino.targetNode }}
+          {{- end }}
 
-            # Pass in the name of the node on which this pod is scheduled
-            # This is not actually used right now... will be in the future
-            - name: NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
+          containers:
+            - name: {{ .Values.kamino.name }}
+              image: {{ template "image.full" .Values.kamino.container }}
+              imagePullPolicy: {{ template "image.pull" .Values.kamino.container }}
 
-          volumeMounts:
+              command:
+                - vmss-prototype
+              args:
+                - --in-cluster
+                - --log-level
+                - {{ required "missing required kamino.logLevel" .Values.kamino.logLevel }}
+
+                {{- if hasKey .Values.kamino "targetVMSS" }}
+                - --log-prefix
+                - auto-update
+                - auto-update
+                - --new-updated-nodes
+                - {{ .Values.kamino.newUpdatedNodes | quote }}
+                - --grace-period
+                - {{ required "missing required kamino.drain.gracePeriod" .Values.kamino.drain.gracePeriod | quote }}
+                - --max-history
+                - {{ required "missing required kamino.imageHistory" .Values.kamino.imageHistory | quote }}
+
+                {{- if not (eq .Values.kamino.targetVMSS "ALL") }}
+                - --target-vmss
+                - {{ .Values.kamino.targetVMSS | quote }}
+                {{- end }}
+
+                - --last-patch-annotation
+                - {{ required "missing requires kamino.auto.lastPatchAnnotation" .Values.kamino.auto.lastPatchAnnotation | quote }}
+                - --pending-reboot-annotation
+                - {{ required "missing requires kamino.auto.pendingRebootAnnotation" .Values.kamino.auto.pendingRebootAnnotation | quote }}
+                - --minimum-ready-time
+                - {{ .Values.kamino.auto.minimumReadyTime | quote }}
+                - --minimum-candidates
+                - {{ .Values.kamino.auto.minimumCandidates | quote }}
+                - --maximum-image-age
+                - {{ .Values.kamino.auto.maximumImageAge | quote }}
+
+                {{- if .Values.kamino.auto.dryRun }}
+                - --dry-run
+                {{- end }}
+
+                {{- else if hasKey .Values.kamino "targetNode" }}
+                # Use the target node as our source for the new prototype image
+                - update
+                - --target-node
+                - {{ .Values.kamino.targetNode | quote }}
+                - --new-updated-nodes
+                - {{ .Values.kamino.newUpdatedNodes | quote }}
+                - --grace-period
+                - {{ required "missing required kamino.drain.gracePeriod" .Values.kamino.drain.gracePeriod | quote }}
+                - --max-history
+                - {{ required "missing required kamino.imageHistory" .Values.kamino.imageHistory | quote }}
+
+                {{- else }}
+                # Just a status run
+                - status
+                {{- end }}
+
+              env:
+                # We use the in-cluster kubeconfig
+                - name: KUBECONFIG
+                  value: /.kubeconfig
+
+                # This gets mapped here since the node has cloud local CA bundles we need
+                - name: REQUESTS_CA_BUNDLE
+                  value: /etc/ssl/certs/ca-certificates.crt
+
+                # Pass in the name of the node on which this pod is scheduled
+                # This is not actually used right now... will be in the future
+                - name: NODE_ID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+
+              volumeMounts:
+                - name: host-sp
+                  mountPath: /etc/kubernetes
+                  readOnly: true
+                - name: kubectl
+                  mountPath: /usr/bin/kubectl
+                  readOnly: true
+                - name: kubeconfig
+                  mountPath: /.kubeconfig
+                  readOnly: true
+                - name: host-crt
+                  mountPath: /etc/ssl/certs/ca-certificates.crt
+                  readOnly: true
+
+          volumes:
             - name: host-sp
-              mountPath: /etc/kubernetes
-              readOnly: true
+              hostPath:
+                # this file contains the cluster specific details, including azure info
+                path: /etc/kubernetes
+                type: Directory
+
             - name: kubectl
-              mountPath: /usr/bin/kubectl
-              readOnly: true
+              hostPath:
+                path: /usr/local/bin/kubectl
+                type: File
+
             - name: kubeconfig
-              mountPath: /.kubeconfig
-              readOnly: true
+              hostPath:
+                path: /var/lib/kubelet/kubeconfig
+                type: File
+
             - name: host-crt
-              mountPath: /etc/ssl/certs/ca-certificates.crt
-              readOnly: true
+              hostPath:
+                path: /etc/ssl/certs/ca-certificates.crt
+                type: File
 
-      volumes:
-        - name: host-sp
-          hostPath:
-            # this file contains the cluster specific details, including azure info
-            path: /etc/kubernetes
-            type: Directory
-
-        - name: kubectl
-          hostPath:
-            path: /usr/local/bin/kubectl
-            type: File
-
-        - name: kubeconfig
-          hostPath:
-            path: /var/lib/kubelet/kubeconfig
-            type: File
-
-        - name: host-crt
-          hostPath:
-            path: /etc/ssl/certs/ca-certificates.crt
-            type: File
-
-      # Tolerate the AKS Engine control plane taint, to accommodate clusters with only one VMSS node
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Equal
-        value: "true"
-        effect: NoSchedule
-      # We really only want linux nodes (this is of no use for Windows nodes)
-      nodeSelector:
-        # Optionally, require scheduling the pod onto a control plane VM using the AKS Engine control plane VM identifier
-        {{- if .Values.kamino.scheduleOnControlPlane }}
-        kubernetes.io/role: master
-        {{- end }}
-        beta.kubernetes.io/os: linux
+          # Tolerate the AKS Engine control plane taint, to accommodate clusters with only one VMSS node
+          tolerations:
+          - key: node-role.kubernetes.io/master
+            operator: Equal
+            value: "true"
+            effect: NoSchedule
+          # We really only want linux nodes (this is of no use for Windows nodes)
+          nodeSelector:
+            # Optionally, require scheduling the pod onto a control plane VM using the AKS Engine control plane VM identifier
+            {{- if .Values.kamino.scheduleOnControlPlane }}
+            kubernetes.io/role: master
+            {{- end }}
+            beta.kubernetes.io/os: linux
 {{- end }}

--- a/helm/vmss-prototype/templates/vmss-prototype.yaml
+++ b/helm/vmss-prototype/templates/vmss-prototype.yaml
@@ -119,6 +119,16 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
 
+            # Our namespace (to run our operation on)
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+
+            # Our image - we use it for a quick fixup on a node
+            - name: POD_IMAGE
+              value: {{ template "image.full" .Values.kamino.container }}
+
           volumeMounts:
             - name: host-sp
               mountPath: /etc/kubernetes

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -72,7 +72,23 @@ kamino:
     # pending a servicing reboot.  We don't want pending reboot nodes
     #pendingRebootAnnotation: weave.works/kured-reboot-in-progress
 
+    # Set this to true such that auto-updates will only show what they
+    # would have done without actually doing it
     dryRun: false
+
+    # If you are running in "automatic mode" you likely will want to have this
+    # run periodically (a cron job).  This only takes effect if you have set
+    # targetVMSS and kamino.auto.cronjob.enabled is true
+    cronjob:
+      enabled: false
+
+      # This is the schedule in standard cron syntax.  Note that the job will
+      # only be running one at a time.  In some of my clusters, I run this every
+      # hour.
+      #schedule: "42 * * * *"
+
+      # A reasonable default is to do it every day.  (Obviously, only if enalbed)
+      schedule: "42 0 * * *"
 
   # This is the log-level for the process via python logging.
   # Each level includes all below it, so DEBUG includes INFO, WARNING, etc...

--- a/vmss-prototype/smoketest2.sh
+++ b/vmss-prototype/smoketest2.sh
@@ -44,6 +44,10 @@ ${HELM3} upgrade --install smoke-test ../helm/vmss-prototype \
 
 kubectl get jobs -lapp=kamino-vmss-prototype
 
-# Note that I do this here knowing that it will never exit and that
-# I am just watching it start/etc.  That was the whole point.
-kubectl get pods -o wide -lapp=kamino-vmss-prototype -w
+# We background start the watch on the pod and then wait for
+# the job to complete and then get the logs
+kubectl get pods -o wide -lapp=kamino-vmss-prototype -w &
+pod_watcher=$?
+kubectl wait jobs --for condition=Complete -lapp=kamino-vmss-prototype
+kubectl logs -lapp=kamino-vmss-prototype --tail 9999 --timestamps --follow
+kill ${pod_watcher}

--- a/vmss-prototype/smoketest2.sh
+++ b/vmss-prototype/smoketest2.sh
@@ -48,6 +48,6 @@ kubectl get jobs -lapp=kamino-vmss-prototype
 # the job to complete and then get the logs
 kubectl get pods -o wide -lapp=kamino-vmss-prototype -w &
 pod_watcher=$?
-kubectl wait jobs --for condition=Complete -lapp=kamino-vmss-prototype
+kubectl wait jobs --for condition=Complete -lapp=kamino-vmss-prototype --timeout 600s
 kubectl logs -lapp=kamino-vmss-prototype --tail 9999 --timestamps --follow
 kill ${pod_watcher}

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -412,12 +412,19 @@ def image_tweaks(node_name):
                  "    name: etc\n"
                 ).format(pod_name, namespace, image, node_name)
 
-    run(['kubectl', 'delete', 'pod',
-         '--namespace', namespace,
-         pod_name
-         ], check=False)
-
-    _, _, rc = run(['kubectl', 'create', '-f', '-'], stdin=yaml_text, retries=3, check=False)
+    run(['kubectl', 'delete', '-f', '-'],
+        stdin=yaml_text,
+        retries=3,
+        check=False,
+        retry_func=not_found_no_retry,
+        comment='Deleting {0} (just in case)'.format(pod_name)
+        )
+    _, _, rc = run(['kubectl', 'create', '-f', '-'],
+                   stdin=yaml_text,
+                   retries=3,
+                   check=False,
+                   comment='Creating {0}'.format(pod_name)
+                   )
 
     if rc:
         logging.info('Could not successfully deploy the image tweaks')
@@ -431,12 +438,19 @@ def image_tweaks(node_name):
          '--namespace', namespace,
          '--follow',
          pod_name
-         ], retries=6, check=False)
+         ],
+         retries=6,
+         check=False,
+         comment='Waiting for {0} to complete'.format(pod_name)
+         )
 
-    run(['kubectl', 'delete', 'pod',
-         '--namespace', namespace,
-         pod_name
-         ], check=False)
+    run(['kubectl', 'delete', '-f', '-'],
+        stdin=yaml_text,
+        retries=3,
+        check=False,
+        retry_func=not_found_no_retry,
+        comment='Deleting {0}'.format(pod_name)
+        )
 
     return True
 

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -393,8 +393,8 @@ def image_tweaks(node_name):
                  "    imagePullPolicy: IfNotPresent\n"
                  "    name: tweaks\n"
                  "    volumeMounts:\n"
-                 "    - mountPath: /hostetc\n"
-                 "      name: etc\n"
+                 "    - mountPath: /hostetc/machine-id\n"
+                 "      name: machineid\n"
                  "      readOnly: false\n"
                  "  hostNetwork: true\n"
                  "  nodeSelector:\n"
@@ -407,9 +407,9 @@ def image_tweaks(node_name):
                  "    operator: Exists\n"
                  "  volumes:\n"
                  "  - hostPath:\n"
-                 "      path: /etc\n"
-                 "      type: Directory\n"
-                 "    name: etc\n"
+                 "      path: /etc/machine-id\n"
+                 "      type: File\n"
+                 "    name: machineid\n"
                 ).format(pod_name, namespace, image, node_name)
 
     run(['kubectl', 'delete', '-f', '-'],

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -401,7 +401,6 @@ def image_tweaks(node_name):
                  "  - name: skyman-acr\n"
                  "  nodeSelector:\n"
                  "    kubernetes.io/hostname: '{3}'\n"
-                 "  priorityClassName: skyman-cluster-daemonset\n"
                  "  restartPolicy: Never\n"
                  "  tolerations:\n"
                  "  - effect: NoSchedule\n"

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -397,8 +397,6 @@ def image_tweaks(node_name):
                  "      name: etc\n"
                  "      readOnly: false\n"
                  "  hostNetwork: true\n"
-                 "  imagePullSecrets:\n"
-                 "  - name: skyman-acr\n"
                  "  nodeSelector:\n"
                  "    kubernetes.io/hostname: '{3}'\n"
                  "  restartPolicy: Never\n"

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -352,6 +352,98 @@ def get_vmss_images(subscription, resource_group, sig_name, image_definition):
     return json.loads(output)
 
 
+def image_tweaks(node_name):
+    """
+    If we have the information needed, do our image tweaks pod on the
+    target node.  This runs as a one-shot pod that will address image
+    tweaks.  Currently, that is only 1 item - the /etc/machine-id must
+    be emptied (but not deleted) such that a new unique machine-id can
+    be created for each new node.
+    The yaml specifically supports running on a cordoned node and it
+    also specifically calls out the node in question.
+    :param node_name:  The node, after it has been drained but it is still up
+    :returns: True if the tweaks were successfully deployed
+    """
+    namespace = os.getenv('POD_NAMESPACE', None)
+    if not namespace:
+        logging.info('No POD_NAMESPACE defined, can not do image tweaks')
+        return False
+
+    image = os.getenv('POD_IMAGE', None)
+    if not image:
+        logging.info('No POD_IMAGE defined, can not do image tweaks')
+        return False
+
+    pod_name = 'vmss-prototype-tweaks-{0}'.format(node_name)
+
+    # This is a pod yaml for our image tweak we will do on the target node
+    # that will be our new prototype image.
+    yaml_text = ("apiVersion: v1\n"
+                 "kind: Pod\n"
+                 "metadata:\n"
+                 "  name: '{0}'\n"
+                 "  namespace: '{1}'\n"
+                 "spec:\n"
+                 "  containers:\n"
+                 "  - command:\n"
+                 "    - /bin/cp\n"
+                 "    - /dev/null\n"
+                 "    - /hostetc/machine-id\n"
+                 "    image: '{2}'\n"
+                 "    imagePullPolicy: IfNotPresent\n"
+                 "    name: tweaks\n"
+                 "    volumeMounts:\n"
+                 "    - mountPath: /hostetc\n"
+                 "      name: etc\n"
+                 "      readOnly: false\n"
+                 "  hostNetwork: true\n"
+                 "  imagePullSecrets:\n"
+                 "  - name: skyman-acr\n"
+                 "  nodeSelector:\n"
+                 "    kubernetes.io/hostname: '{3}'\n"
+                 "  priorityClassName: skyman-cluster-daemonset\n"
+                 "  restartPolicy: Never\n"
+                 "  tolerations:\n"
+                 "  - effect: NoSchedule\n"
+                 "    operator: Exists\n"
+                 "  - effect: NoExecute\n"
+                 "    operator: Exists\n"
+                 "  volumes:\n"
+                 "  - hostPath:\n"
+                 "      path: /etc\n"
+                 "      type: Directory\n"
+                 "    name: etc\n"
+                ).format(pod_name, namespace, image, node_name)
+
+    run(['kubectl', 'delete', 'pod',
+         '--namespace', namespace,
+         pod_name
+         ], check=False)
+
+    _, _, rc = run(['kubectl', 'create', '-f', '-'], stdin=yaml_text, retries=3, check=False)
+
+    if rc:
+        logging.info('Could not successfully deploy the image tweaks')
+        return False
+
+    # We use this to watch for the pod to complete.  Unfortunately there is
+    # no condition for completed so the kubectl wait command can not work
+    # here and trying to use it for Ready ends up in a race with completion.
+    # Thus, we use the logs method.  Not as pretty but it works.
+    run(['kubectl', 'logs',
+         '--namespace', namespace,
+         '--follow',
+         pod_name
+         ], retries=6, check=False)
+
+    run(['kubectl', 'delete', 'pod',
+         '--namespace', namespace,
+         pod_name
+         ], check=False)
+
+    return True
+
+
 def vmss_prototype_collect_status(sub_args):
     """
     Gather information about VMSS Prototype deployment in the cluster
@@ -720,6 +812,11 @@ def vmss_prototype_update(sub_args):
                                  '--namespace', namespace,
                                  pod
                                  ], retries=3, check=False, retry_func=not_found_no_retry)
+
+                # Now apply the image tweaks that we want.  Note that this
+                # works because the yaml we build allows it to run on cordoned
+                # nodes.
+                image_tweaks(target_node)
 
                 # Stop the VM now (deallocate it such that the disk image can be accessed)
                 run(az(['vmss', 'deallocate'], subscription) + [


### PR DESCRIPTION
Kamino is designed to be lights-out operation.  As such, it can
be installed as a crontab that runs the auto-update process on
a regular basis.

In most of our clusters, we run this automatic update process on
a daily basis.  Since OS updates usually don't happen daily, this
ends up just checking and noting that there is nothing to do.

When an OS update does happen (or the age limit on the prior image
is reached) then the auto-update process does what it needs to do.

This allows the whole thing to be running in clusters without
intervention.

The schedule could easily be run more often as the cronjob is set
up to not run while a prior instance is running.  I run my test
clusters with this turned to running every few minutes just to
stress test the logic and to quickly notice a condition where a
new image is needed (just to reduce testing time).

This fixes #44

Enhanced smoketest3.sh a bit to make it do what I needed.

The new smoketest4.sh is just like smoketest3.sh only it uses the
cronjob (with an "every minute" schedule) to run the cronjob and
then uninstalls after it completes so as to not continually rerun.
It is just a smoketest of the chart...