### PR TITLE
Update chart to include latest VMSS-Prototype container image

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Kamino vmss-prototype pattern image generator
 name: vmss-prototype
-version: 0.0.7
+version: 0.0.8
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -8,9 +8,9 @@ kamino:
     # TODO:  Point these to our public container registry once we have it setup
     imageRegistry: ghcr.io
     imageRepository: jackfrancis/kamino/vmss-prototype
-    imageTag: v0.0.6
+    imageTag: v0.0.8
     # Pulling by hash has stronger assurance that the container is unchanged
-    imageHash: "d154002ee4db8ca691357b7cc7ceb864d3e00f67a8a1be5554d749469d609c3f"
+    imageHash: "26bef983e30edc597c932d8ca3246f949638fae738888109649f4e26a770f4a0"
     pullByHash: true
 
     # include the name of the image pull secret in your cluster if you


### PR DESCRIPTION
This updates the chart to use VMSS-Prototype v0.0.8 container,
sha256:26bef983e30edc597c932d8ca3246f949638fae738888109649f4e26a770f4a0

This includes the Machine-ID duplication fix #22