### PR TITLE
ci: use pull_request_target, ignore az warnings

### DIFF
--- a/.github/workflows/build-and-test-vmss-prototype-image.yml
+++ b/.github/workflows/build-and-test-vmss-prototype-image.yml
@@ -5,7 +5,7 @@ on:
       image_tag:
         description: 'Identify image by this tag'
         required: true
-  pull_request:
+  pull_request_target:
     paths:
       - vmss-prototype/vmss-prototype
       - vmss-prototype/Dockerfile

--- a/.github/workflows/build-and-test-vmss-prototype-image.yml
+++ b/.github/workflows/build-and-test-vmss-prototype-image.yml
@@ -81,5 +81,6 @@ jobs:
           GINKGO_FOCUS: "should be able to install vmss node prototype"
           RUN_VMSS_NODE_PROTOTYPE: true
           KAMINO_VMSS_PROTOTYPE_IMAGE_TAG: ${{ env.RELEASE_VERSION }}
+          AZURE_CORE_ONLY_SHOW_ERRORS: True
         run: make test-kubernetes
         working-directory: aks-engine

--- a/.github/workflows/build-and-test-vmss-prototype-image.yml
+++ b/.github/workflows/build-and-test-vmss-prototype-image.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: azure/login@v1
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          credentials: ${{ secrets.AZURE_CREDENTIALS }}
       - name: assign tag based on manual input
         run: echo "RELEASE_VERSION=${{github.event.inputs.image_tag}}-canary" >> $GITHUB_ENV
         if: ${{github.event.inputs.image_tag != ''}}

--- a/.github/workflows/build-and-test-vmss-prototype-image.yml
+++ b/.github/workflows/build-and-test-vmss-prototype-image.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: azure/login@v1
         with:
-          credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: assign tag based on manual input
         run: echo "RELEASE_VERSION=${{github.event.inputs.image_tag}}-canary" >> $GITHUB_ENV
         if: ${{github.event.inputs.image_tag != ''}}

--- a/.github/workflows/test-vmss-prototype-helm-chart.yml
+++ b/.github/workflows/test-vmss-prototype-helm-chart.yml
@@ -87,5 +87,6 @@ jobs:
           RUN_VMSS_NODE_PROTOTYPE: true
           KAMINO_VMSS_PROTOTYPE_LOCAL_CHART_PATH: ${{ github.workspace }}/helm/vmss-prototype
           KAMINO_VMSS_PROTOTYPE_DRY_RUN: ${{ env.DRY_RUN }}
+          AZURE_CORE_ONLY_SHOW_ERRORS: True
         run: make test-kubernetes
         working-directory: aks-engine

--- a/.github/workflows/test-vmss-prototype-helm-chart.yml
+++ b/.github/workflows/test-vmss-prototype-helm-chart.yml
@@ -6,7 +6,7 @@ on:
         description: 'Perform dry run?'
         required: true
         default: 'true'
-  pull_request:
+  pull_request_target:
     paths:
       - helm/vmss-prototype/Chart.yaml
       - helm/vmss-prototype/values.yaml

--- a/.github/workflows/test-vmss-prototype-helm-chart.yml
+++ b/.github/workflows/test-vmss-prototype-helm-chart.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: azure/login@v1
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          credentials: ${{ secrets.AZURE_CREDENTIALS }}
       - name: assign tag automatically based on current commit sha
         run: echo "RELEASE_VERSION=$(git rev-parse --short "$GITHUB_SHA")-canary" >> $GITHUB_ENV
       - name: assign dry run config on manual input

--- a/.github/workflows/test-vmss-prototype-helm-chart.yml
+++ b/.github/workflows/test-vmss-prototype-helm-chart.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: azure/login@v1
         with:
-          credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: assign tag automatically based on current commit sha
         run: echo "RELEASE_VERSION=$(git rev-parse --short "$GITHUB_SHA")-canary" >> $GITHUB_ENV
       - name: assign dry run config on manual input


### PR DESCRIPTION
This PR makes two changes to the github actions CI config:

1. use `pull_request_target` instead of `pull_request`, to allow the secrets in this repository to be re-used by PRs. See:
  - https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
2. pass in the `AZURE_CORE_ONLY_SHOW_ERRORS=true` environment config for invoking aks-engine E2E, to suppress `az` warning output from surprising the test runner