### PR TITLE
Add "apt-get upgrade" to our build

### DIFF
--- a/vmss-prototype/Dockerfile
+++ b/vmss-prototype/Dockerfile
@@ -7,7 +7,8 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-suggests --no-install-recommends --yes \
+    apt-get upgrade --yes && \
+    apt-get install --no-install-suggests --no-install-recommends --yes \
         apt-transport-https \
         ca-certificates \
         curl \


### PR DESCRIPTION
There are a few security patches that are not yet in the base
container so we apt-get upgrade them to get them.

This is just good practice and it was unfortunate that I had
somehow missed including it here.