### PR TITLE
Update chart to use v0.0.10 image

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Kamino vmss-prototype pattern image generator
 name: vmss-prototype
-version: 0.0.9
+version: 0.0.10
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -8,9 +8,9 @@ kamino:
     # TODO:  Point these to our public container registry once we have it setup
     imageRegistry: ghcr.io
     imageRepository: jackfrancis/kamino/vmss-prototype
-    imageTag: v0.0.9
+    imageTag: v0.0.10
     # Pulling by hash has stronger assurance that the container is unchanged
-    imageHash: "904b906e98009387f78cf2224be7805b27643cceba7c8bc03b35990b60df5a3f"
+    imageHash: "dfdb706f22afec76e69c0a9bbe8ed0bd163716d94575d2bccbad26e73f77a3a0"
     pullByHash: true
 
     # include the name of the image pull secret in your cluster if you


### PR DESCRIPTION
The new image is no different than v0.0.9 other than some
security fixes from Ubuntu/Debian.  It is a rebuild but
since we run strict identity for the image, it requires
an update to the chart to pick that specific build.