### PR TITLE
Update chart to v0.0.11 such that it uses container v0.0.11

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Kamino vmss-prototype pattern image generator
 name: vmss-prototype
-version: 0.0.10
+version: 0.0.11
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -8,9 +8,9 @@ kamino:
     # TODO:  Point these to our public container registry once we have it setup
     imageRegistry: ghcr.io
     imageRepository: jackfrancis/kamino/vmss-prototype
-    imageTag: v0.0.10
+    imageTag: v0.0.11
     # Pulling by hash has stronger assurance that the container is unchanged
-    imageHash: "dfdb706f22afec76e69c0a9bbe8ed0bd163716d94575d2bccbad26e73f77a3a0"
+    imageHash: "e26ef9f67e07f666b6877196084f3ca95547835d83ba4d1e4d0892dc20c14faa"
     pullByHash: true
 
     # include the name of the image pull secret in your cluster if you


### PR DESCRIPTION
This gets the latest container which no longer has the delete of the donor node.

This also was a fresh build so it has the latest patches for OpenSSL vulnerabilities and the newest AzureCLI

```
docker history ghcr.io/jackfrancis/kamino/vmss-prototype:v0.0.11
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
89429007a2d9   7 minutes ago   ENTRYPOINT ["/usr/bin/vmss-prototype"]          0B        buildkit.dockerfile.v0
<missing>      7 minutes ago   COPY vmss-prototype /usr/bin/ # buildkit        87.2kB    buildkit.dockerfile.v0
<missing>      7 minutes ago   RUN /bin/sh -c echo "Install AzureCLI" &&   …   789MB     buildkit.dockerfile.v0
<missing>      7 minutes ago   RUN /bin/sh -c apt-get update &&     apt-get…   66.2MB    buildkit.dockerfile.v0
<missing>      7 days ago      /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B        
<missing>      7 days ago      /bin/sh -c mkdir -p /run/systemd && echo 'do…   7B        
<missing>      7 days ago      /bin/sh -c [ -z "$(apt-get indextargets)" ]     0B        
<missing>      7 days ago      /bin/sh -c set -xe   && echo '#!/bin/sh' > /…   811B      
<missing>      7 days ago      /bin/sh -c #(nop) ADD file:a8d2f02fbaddf8cec…   72.9MB    
```