### PR TITLE
release: v0.0.12

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Kamino vmss-prototype pattern image generator
 name: vmss-prototype
-version: 0.0.11
+version: 0.0.12
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -8,9 +8,9 @@ kamino:
     # TODO:  Point these to our public container registry once we have it setup
     imageRegistry: ghcr.io
     imageRepository: jackfrancis/kamino/vmss-prototype
-    imageTag: v0.0.11
+    imageTag: v0.0.12
     # Pulling by hash has stronger assurance that the container is unchanged
-    imageHash: "e26ef9f67e07f666b6877196084f3ca95547835d83ba4d1e4d0892dc20c14faa"
+    imageHash: "418cabda69afed714b33f5ee150c9683443725e9a8f7fb7d953f8372e34ad208"
     pullByHash: true
 
     # include the name of the image pull secret in your cluster if you


### PR DESCRIPTION
This PR will cut a v0.0.12 release of the kamino chart, with a reference to a newly built vmss-prototype image:

https://github.com/users/jackfrancis/packages/container/kamino%2Fvmss-prototype/2541102?tag=v0.0.12

v0.0.12 of vmss-prototype is a "housekeeping" release, built from ubuntu-20.04 on 2021-05-14 in order to freshen OS surface area:

https://github.com/jackfrancis/kamino/actions/runs/843673844