### PR TITLE
Update to pick up latest container image

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Kamino vmss-prototype pattern image generator
 name: vmss-prototype
-version: 0.0.13
+version: 0.0.14
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -8,9 +8,9 @@ kamino:
     # TODO:  Point these to our public container registry once we have it setup
     imageRegistry: ghcr.io
     imageRepository: jackfrancis/kamino/vmss-prototype
-    imageTag: v0.0.12
+    imageTag: v0.0.14
     # Pulling by hash has stronger assurance that the container is unchanged
-    imageHash: "418cabda69afed714b33f5ee150c9683443725e9a8f7fb7d953f8372e34ad208"
+    imageHash: "18668610ed57099107e8509c6293eb40bd6963da094dcfc3de0ced51732d8569"
     pullByHash: true
 
     # include the name of the image pull secret in your cluster if you


### PR DESCRIPTION
We needed a container image update to pick up the latest base image
for the container plus the change that makes this work with multi-MSI
assigned VM instances.  See issue #79 and fix PR #80