### PR TITLE
use non-deprecated node selector

### DIFF
--- a/helm/vmss-prototype/templates/vmss-prototype.yaml
+++ b/helm/vmss-prototype/templates/vmss-prototype.yaml
@@ -219,5 +219,5 @@ spec:
             {{- if .Values.kamino.scheduleOnControlPlane }}
             kubernetes.io/role: master
             {{- end }}
-            beta.kubernetes.io/os: linux
+            kubernetes.io/os: linux
 {{- end }}


### PR DESCRIPTION
This PR updates the OS nodeSelector key to use the non-deprecated interface.

For example, when running against a 1.22 cluster we get this warning message:

```
warnings.go:70] spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use "kubernetes.io/os" instead
```