### PR TITLE
Add workaround for observed strange behavior

### DIFF
--- a/vmss-prototype/smoketest2.sh
+++ b/vmss-prototype/smoketest2.sh
@@ -45,6 +45,7 @@ ${HELM3} upgrade --install ${DEPLOYMENT_NAME} ../helm/vmss-prototype \
     --set kamino.container.imageTag=${MY_TAG} \
     --set kamino.container.pullByHash=false \
     --set kamino.container.pullSecret=skyman-acr \
+    --set kamino.scheduleOnControlPlane=true \
     --set kamino.drain.gracePeriod=5 \
     --set kamino.drain.force=true \
     #--set kamino.targetNode=k8s-agentpool1-18861755-vmss000007

--- a/vmss-prototype/smoketest3.sh
+++ b/vmss-prototype/smoketest3.sh
@@ -36,6 +36,7 @@ ${HELM3} upgrade --install ${DEPLOYMENT_NAME} ../helm/vmss-prototype \
     --set kamino.auto.lastPatchAnnotation=LatestOSPatch \
     --set kamino.auto.pendingRebootAnnotation=PendingReboot \
     --set kamino.auto.maximumImageAge=15 \
+    --set kamino.scheduleOnControlPlane=true \
     --set kamino.auto.dryRun=true
 
 # Show the commands we are about to run

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -1016,12 +1016,20 @@ def vmss_prototype_update(sub_args):
     # Get the VMSS extensions and see if we can clean them up
     # Note that we could potentially loop here since we have seen a delete
     # report success but not actually delete the extension.  So we can try
-    # this loop up to 5 times (just in case)
-    delete_tries = 5
+    # this loop up to 5 times (just in case).  It always loops once to check
+    # that the delete actually took place (re-listing the extensions)
+    delete_tries = 0
     delete_extensions = True
-    while delete_extensions and delete_tries > 0:
-        delete_tries = delete_tries - 1
+    while delete_extensions and delete_tries < 5:
         delete_extensions = False
+
+        # If this is our 3rd or higher time through, we want to sleep a bit
+        # to allow whatever failure to delete that was happening to clear up
+        if delete_tries > 1:
+            logging.info('Already did {0} attempts at deleting extensions - delaying a bit before next attempt'.format(delete_tries))
+            # This is a linear backoff - we should never get here but
+            time.sleep(delete_tries * 30)
+
         output, _, _ = run(az(['vmss', 'extension', 'list'], subscription) + [
                            '--resource-group', resource_group,
                            '--vmss-name', vmss
@@ -1041,8 +1049,10 @@ def vmss_prototype_update(sub_args):
                     '--name', extension['name']
                     ], retries=3, check=False, retry_func=not_found_no_retry, log_retry_errors=True)
 
+        delete_tries = delete_tries + 1
+
     if sub_args.new_updated_nodes > 0:
-        # Scale out 1 more VMSS instance to replace the previously deleted instance
+        # Scale out more VMSS instances if asked, using the new prototype image
         # Note: this does not respect any changes that may have occured to the VMSS instance count during update
         # from out-of-band node scaling tools such as cluster-autoscaler
         output, _, _ = run(az(['vmss', 'show'], subscription) + [
@@ -1051,14 +1061,14 @@ def vmss_prototype_update(sub_args):
                            ], retries=3)
         vmss_info = json.loads(output)
         capacity = lookup_one_value(vmss_info, 'sku.capacity')
-        if capacity != None:
+        if capacity is not None:
             # Increase the capacity of the VMSS by the value of --new-updated-nodes
             run(az(['vmss', 'update'], subscription) + [
                 '--resource-group', resource_group,
                 '--name', vmss,
                 '--set',
                     'sku.capacity={0}'.format(capacity + sub_args.new_updated_nodes),
-                "--no-wait"
+                '--no-wait'
                 ], retries=3, check=False)
         else:
             logging.warning('Unable to determine capacity for VMSS {0}, will not add back 1 instance'.format(vmss))

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -1014,32 +1014,41 @@ def vmss_prototype_update(sub_args):
             fatal_error('VMSS {0} failed to be configured to use prototype iamge'.format(vmss))
 
     # Get the VMSS extensions and see if we can clean them up
-    output, _, _ = run(az(['vmss', 'extension', 'list'], subscription) + [
-                       '--resource-group', resource_group,
-                       '--vmss-name', vmss
-                       ], retries=3)
-    extensions = json.loads(output)
+    # Note that we could potentially loop here since we have seen a delete
+    # report success but not actually delete the extension.  So we can try
+    # this loop up to 5 times (just in case)
+    delete_tries = 5
+    delete_extensions = True
+    while delete_extensions and delete_tries > 0:
+        delete_tries = delete_tries - 1
+        delete_extensions = False
+        output, _, _ = run(az(['vmss', 'extension', 'list'], subscription) + [
+                           '--resource-group', resource_group,
+                           '--vmss-name', vmss
+                           ], retries=3)
+        extensions = json.loads(output)
 
-    for extension in extensions:
-        # Now that we have a disk image that already has all of our
-        # provisioning bits on it (prototype) we can remove all extensions
-        # But...  We want to keep the AKS Engine-identifying extension for telemetry reasons
-        # It is a no-op code wise but gives counts
-        if 'vmss-computeAksLinuxBilling' not in extension['name']:
-            run(az(['vmss', 'extension', 'delete'], subscription) + [
-                '--resource-group', resource_group,
-                '--vmss-name', vmss,
-                '--name', extension['name']
-                ], retries=3, check=False, retry_func=not_found_no_retry)
+        for extension in extensions:
+            # Now that we have a disk image that already has all of our
+            # provisioning bits on it (prototype) we can remove all extensions
+            # But...  We want to keep the AKS Engine-identifying extension for telemetry reasons
+            # It is a no-op code wise but gives counts
+            if 'vmss-computeAksLinuxBilling' not in extension['name']:
+                delete_extensions = True
+                run(az(['vmss', 'extension', 'delete'], subscription) + [
+                    '--resource-group', resource_group,
+                    '--vmss-name', vmss,
+                    '--name', extension['name']
+                    ], retries=3, check=False, retry_func=not_found_no_retry, log_retry_errors=True)
 
     if sub_args.new_updated_nodes > 0:
         # Scale out 1 more VMSS instance to replace the previously deleted instance
         # Note: this does not respect any changes that may have occured to the VMSS instance count during update
         # from out-of-band node scaling tools such as cluster-autoscaler
         output, _, _ = run(az(['vmss', 'show'], subscription) + [
-                        '--resource-group', resource_group,
-                        '--name', vmss
-                        ], retries=3)
+                           '--resource-group', resource_group,
+                           '--name', vmss
+                           ], retries=3)
         vmss_info = json.loads(output)
         capacity = lookup_one_value(vmss_info, 'sku.capacity')
         if capacity != None:


### PR DESCRIPTION
Add workaround for observed strange behavior
    
We had a test run that observed an extension still being configured
even after it was deleted successfully from the configuration.
    
This should fix #83 that was reported

To hopefully address this, we re-list the extensions after trying
to delete them and will re-delete those that we feel we should
delete if they still are there after having deleted them.  We
will do that up to 5 times.

The problem is that at this point the new image has been installed
and set up as the target image so the extensions should not be needed
but we can't undo what we did to install new image.  We can only go
forward.  (There is no single operation that can do it all atomically,
especially since now we see that even a successful delete is not
always successful anyway)
