### PR TITLE
release: v0.0.15

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Kamino vmss-prototype pattern image generator
 name: vmss-prototype
-version: 0.0.14
+version: 0.0.15
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -8,9 +8,9 @@ kamino:
     # TODO:  Point these to our public container registry once we have it setup
     imageRegistry: ghcr.io
     imageRepository: jackfrancis/kamino/vmss-prototype
-    imageTag: v0.0.14
+    imageTag: v0.0.15
     # Pulling by hash has stronger assurance that the container is unchanged
-    imageHash: "18668610ed57099107e8509c6293eb40bd6963da094dcfc3de0ced51732d8569"
+    imageHash: "c926412d8429d2a05c5cb926d32aed722ea9b80b742eafc2b7e9a0eb1b17b5eb"
     pullByHash: true
 
     # include the name of the image pull secret in your cluster if you


### PR DESCRIPTION
This PR will release version `0.0.15` of the vmss-prototype helm chart. Includes:

- https://github.com/jackfrancis/kamino/pull/82
- https://github.com/jackfrancis/kamino/pull/84