### PR TITLE
Minor change to work around an azure CLI bug in 2.30.0

### DIFF
--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -886,10 +886,15 @@ def vmss_prototype_update(sub_args):
                     '--instance-ids', instance_id
                     ], retries=3, log_timing=True, retry_func=not_found_no_retry)
 
+                # NOTE: --copy-start false option is a workaround for
+                # bug in Azure CLI in 2.30.0 but is safe to use as it
+                # does create a snapshot just like we wanted anyway
+                # See https://github.com/Azure/azure-cli/issues/20313
                 output, _, _ = run(az(['snapshot', 'create'], subscription) + [
                                    '--resource-group', resource_group,
                                    '--name', snapshot_name,
                                    '--source', vmss_disk,
+                                   '--copy-start', 'false', # work around azure CLI 2.30.0
                                    '--tags',
                                        'BuiltFrom={0}'.format(target_node),
                                        'BuiltAt={0}'.format(datetime.datetime.now().strftime(snapshot_time_format))

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -862,7 +862,8 @@ def vmss_prototype_update(sub_args):
                     # drained (they should have drained already but just in case)
                     pods, _, _ = run(['kubectl', 'get', 'pods',
                                       '--all-namespaces',
-                                      '--output', 'jsonpath={{range .items[?(@.spec.nodeName=="{0}")]}}{{.metadata.ownerReferences[0].kind}}{{" "}}{{.metadata.namespace}}{{" "}}{{.metadata.name}}{{"\\n"}}{{end}}'.format(target_node)
+                                      '--field-selector', 'spec.nodeName={0}'.format(target_node),
+                                      '--output', 'jsonpath={range .items[*]}{.metadata.ownerReferences[0].kind}{" "}{.metadata.namespace}{" "}{.metadata.name}{"\\n"}{end}'
                                       ], retries=3)
 
                     for line in pods.splitlines():


### PR DESCRIPTION
The latest Azure CLI has a bug where it break the snapshot
command when run against a VMSS disk instance.  Turns out that
there is a simple workaround that is perfectly fine to use as
it just forces the path that we normally would have gone down
anyway.

See https://github.com/Azure/azure-cli/issues/20313