### PR TITLE
release: 0.0.16

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Kamino vmss-prototype pattern image generator
 name: vmss-prototype
-version: 0.0.15
+version: 0.0.16
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com

--- a/helm/vmss-prototype/values.yaml
+++ b/helm/vmss-prototype/values.yaml
@@ -8,9 +8,9 @@ kamino:
     # TODO:  Point these to our public container registry once we have it setup
     imageRegistry: ghcr.io
     imageRepository: jackfrancis/kamino/vmss-prototype
-    imageTag: v0.0.15
+    imageTag: v0.0.16
     # Pulling by hash has stronger assurance that the container is unchanged
-    imageHash: "c926412d8429d2a05c5cb926d32aed722ea9b80b742eafc2b7e9a0eb1b17b5eb"
+    imageHash: "be201a6a9de83aba5ebb38a6b3cddecddac6b2a5cc8d064d410810b0a43ab0e0"
     pullByHash: true
 
     # include the name of the image pull secret in your cluster if you


### PR DESCRIPTION
This PR delivers a new release of the canonical helm chart, with a reference to the newly published `v0.0.16` container image.

Includes two changes:

- https://github.com/jackfrancis/kamino/pull/87
- https://github.com/jackfrancis/kamino/pull/88