### PR TITLE
Add support for hyper-v generations

### DIFF
--- a/vmss-prototype/Dockerfile
+++ b/vmss-prototype/Dockerfile
@@ -24,9 +24,10 @@ RUN apt-get update && \
     python -m pip install \
         argparse \
         && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* /root/.cache
 
-# Azure CLI (Currently ~789MB all by itself!)
+# Azure CLI (Currently ~1GB all by itself!)
 RUN echo "Install AzureCLI" && \
     curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key add - && \
     echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/azure-cli.list && \

--- a/vmss-prototype/smoketest.sh
+++ b/vmss-prototype/smoketest.sh
@@ -4,7 +4,9 @@ IMAGE_TAG=vmss-prototype:smoke-test
 
 docker build . -t ${IMAGE_TAG}
 
-docker run --rm -i -t ${IMAGE_TAG} --help
+(set -x ; docker history ${IMAGE_TAG})
+
+(set -x ; docker run --rm ${IMAGE_TAG} --help)
 
 # A form to test locally with my local azure login and kubectl from
 # my host machine by mapping in the .azure directory and the KUBECONFIG file
@@ -17,7 +19,7 @@ if [[ ! -z ${KUBECONFIG} ]] &&
    [[ -f ${KUBECONFIG} ]] &&
    [[ -d ${HOME}/.azure ]]
    then
-        docker run --rm -i -t \
+        exec docker run --rm \
             -u ${UID}:${GID} \
             --mount type=bind,source=$(which kubectl),target=/usr/bin/kubectl,readonly \
             --mount type=bind,source=${HOME}/.azure,target=${HOME}/.azure \

--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -689,6 +689,38 @@ def format_into_version(date_time):
     return date_time.strftime('%Y.%m.%d')
 
 
+def get_vmss_hyperv_generation(vmss, resource_group, subscription):
+    """
+    Given a VMSS, resource group, and subscription, this will return the
+    Hyper-v generation of that VMSS.  This is needed such that we can
+    generate the correct image definition for the VMSS.
+    This should only fail if there are no instances to check or if Azure
+    is really confused at the time.
+    :param vmss: The VMSS name
+    :param resource_group: The resource group of the VMSS
+    :param subscription: The subscription of the resource group
+    :return: The hyper-v generation - or none if we fail to get it
+    """
+    instance_id, _, rc = run(az(['vmss', 'list-instances'], subscription) + [
+                                 '--resource-group', resource_group,
+                                 '--name', vmss,
+                                 '--query', '[0].id',
+                                 '--output', 'tsv'
+                                 ], retries=3, check=False)
+
+    instance_id = instance_id.strip()
+    if rc != 0 or not instance_id:
+        return None
+
+    instance, _, rc = run(az(['vmss', 'get-instance-view']) + [
+                              '--ids', instance_id,
+                              '--query', 'hyperVGeneration',
+                              '--output', 'tsv'
+                              ], retries=3, check=False)
+
+    return instance.strip()
+
+
 def vmss_prototype_update(sub_args):
     """
     Update (create if not existing) the prototype based images for the
@@ -751,6 +783,11 @@ def vmss_prototype_update(sub_args):
                         '--gallery-image-definition', image_definition
                         ], retries=3, check=False, retry_func=not_found_no_retry)
     if rc != 0:
+        # If we have to create an image-definition, we need to know the
+        # type of hyper-v-generation that this is running with.
+        hyperv_generation = get_vmss_hyperv_generation(vmss, resource_group, subscription)
+        if not hyperv_generation:
+            fatal_error('Could not determine the hyper-v generation for vmss {0}'.format(vmss))
         output, _, _ = run(az(['sig', 'image-definition', 'create'], subscription) + [
                            '--resource-group', resource_group,
                            '--gallery-name', sig_name,
@@ -758,6 +795,7 @@ def vmss_prototype_update(sub_args):
                            '--publisher', 'VMSS-Prototype-Pattern',
                            '--offer', sub_args.resource_group,
                            '--sku', vmss,
+                           '--hyper-v-generation', hyperv_generation,
                            '--os-type', 'Linux',
                            '--os-state', 'generalized'
                            ], retries=3)


### PR DESCRIPTION
In order to support different hyper-v generations, the SIG image
definition must match the hyper-v generation of the VMSS instances.

This addresses issue #91