### PR TITLE
fix: clusterrole need nodes list

### DIFF
--- a/helm/vmss-prototype/Chart.yaml
+++ b/helm/vmss-prototype/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Kamino vmss-prototype pattern image generator
 name: vmss-prototype
-version: 0.0.17
+version: 0.0.18
 maintainers:
   - name: Michael Sinz
     email: msinz@microsoft.com

--- a/helm/vmss-prototype/templates/vmss-prototype.yaml
+++ b/helm/vmss-prototype/templates/vmss-prototype.yaml
@@ -29,7 +29,7 @@ rules:
   verbs: ["get", "list", "delete", "create"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "patch"]
+  verbs: ["get", "patch", "list"]
 - apiGroups: ["apps"]
   resources: ["statefulsets", "namespaces", "daemonsets", "replicasets"]
   verbs: ["get", "list"]


### PR DESCRIPTION
This PR adds "list nodes" rbac privileges to the clusterrole in response to more manual testing that exposed this bug.