### PR TITLE
Address the potential buildup of journal logs

### DIFF
--- a/vmss-prototype/vmss-prototype
+++ b/vmss-prototype/vmss-prototype
@@ -416,6 +416,10 @@ def image_tweaks(node_name):
             ' /var/lib/cloud/instances/*'
             ' /var/lib/waagent/history/*'
             ' /var/lib/waagent/events/*'
+            # And, clean up the journal logs as they can get
+            # lost on new VMs (old logs just build up)
+            # and journalctl vacuum will not clean them up
+            ' /var/log/journal/*'
             '',
         # This forces the machine-id to be re-issued
         '/bin/cp /dev/null /etc/machine-id',


### PR DESCRIPTION
When a new node is created from a prototype image, the journal logs are generated in a new, unique hashed directory.  This, unfortunately can no longer match the prior directory name and the prior log files are then not cleaned up by the journalctl vacuum processes.  Thus, this could lead to leaking of disk space over time and multiple generations of prototype images.